### PR TITLE
fix: Query params not parsed when route is defaulted to trailing slash

### DIFF
--- a/lib/server/AsenaServer.ts
+++ b/lib/server/AsenaServer.ts
@@ -143,21 +143,40 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
       await this.prepareTopMiddlewares({ controller, routePath });
 
       for (const [name, params] of Object.entries(routes)) {
-        const lastPath = path.join(`${routePath}/`, params.path).replace(/\\/g, '/');
+        let cleanPath = path.join(routePath, params.path).replace(/\\/g, '/');
+        if (cleanPath !== '/' && cleanPath.endsWith('/')) {
+          cleanPath = cleanPath.slice(0, -1);
+        }
 
         const middlewares = await this.prepareRouteMiddleware(params);
         const validatorInstance = await this.prepareValidator(params.validator);
+        const staticServeConfig = await this.prepareStaticServeConfig(params.staticServe);
 
         await this._adapter.registerRoute({
           method: params.method,
-          path: lastPath,
+          path: cleanPath,
           middlewares: middlewares,
           handler: controller[name].bind(controller),
-          staticServe: await this.prepareStaticServeConfig(params.staticServe),
+          staticServe: staticServeConfig,
           validator: validatorInstance,
           controllerName: getTypedMetadata<string>(ComponentConstants.NameKey, controller.constructor),
           controllerBasePath: routePath,
         });
+
+        // register another route with '/'
+        // example; /users and /users/
+        if (cleanPath !== '/') {
+          await this._adapter.registerRoute({
+            method: params.method,
+            path: cleanPath + '/',
+            middlewares: middlewares,
+            handler: controller[name].bind(controller),
+            staticServe: staticServeConfig,
+            validator: validatorInstance,
+            controllerName: getTypedMetadata<string>(ComponentConstants.NameKey, controller.constructor),
+            controllerBasePath: routePath,
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
AsenaJs/Asena#53
Registers an additional route alias to support both standard and trailing slash patterns (e.g., /users and /users/).

```
UserController (/users)
  GET /users
  GET /users/
```