### PR TITLE
Patch v0.9.1 — @Strategy at every cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,47 @@
 # @asenajs/asena
 
+## 0.9.1
+
+### Patch Changes
+
+- `@Strategy` now behaves the same at every cardinality
+
+  `@Strategy` is multi-valued by construction — that is the whole difference from `@Inject`. It was
+  correct at exactly one cardinality:
+
+  | implementations       | before                                                   | now                      |
+  | --------------------- | -------------------------------------------------------- | ------------------------ |
+  | 0                     | boot aborted with `<key> is not registered`              | injected as `[]`         |
+  | 1                     | field held a **bare instance**, not `[instance]`         | injected as `[instance]` |
+  | 1, with an expression | reading the field threw `strategy.map is not a function` | expression applied       |
+  | 2+                    | correct                                                  | unchanged                |
+
+  One root cause. `Container.register()` stores a key's first registration as a bare
+  `ContainerService` and only converts to an array on the second, so `_services[key]` has three
+  shapes — absent, object, array — which `resolve()` maps to throw / `T` / `T[]`. That is right for
+  `@Inject`, whose dependency is single-valued: it is either there or the component is broken.
+  `resolveStrategy` was a cast over that same lookup, so it declared `T[]` for all three.
+
+  The single-implementation case was the more dangerous half. Zero died loudly at boot; one passed
+  boot and failed later at the first `.length`, `for...of` or `.map()`, far from the cause. And
+  because the bug disappears as implementations are added — write the registry (boot dies), add the
+  first plugin (silently wrong), add the second (suddenly works) — it tends to get "fixed" by
+  accident and never diagnosed.
+
+  A strategy key with no implementations is a plugin point before its first plugin, which is the
+  ordinary starting condition of one, not a misconfiguration. This also fixes mocking a strategy key
+  through `createTestApp`'s `overrides`, which produced the same single-implementation shape.
+
+  **API note:** `Container.resolveStrategy` is now `Promise<T[]>` instead of `Promise<T[] | null>`.
+  The `null` half was never reachable — `resolve()` threw instead — so this narrows the type to what
+  the method actually did.
+
+  **New diagnostic:** because an empty key is now silently `[]`, a typo'd interface name no longer
+  fails at boot; it surfaces later as a collection that is always empty. `IocEngine` therefore logs
+  `Strategy key '<key>' has no implementations - <Component>.<field> will be injected as []` once per
+  injection site at boot, at `debug` level, so a deliberate plugin point stays quiet. Keys supplied
+  through `overrides` are not reported.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Asena
 
-[![Version](https://img.shields.io/badge/version-0.9.0-blue.svg)](https://asena.sh)
+[![Version](https://img.shields.io/badge/version-0.9.1-blue.svg)](https://asena.sh)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
 [![Bun Version](https://img.shields.io/badge/Bun-1.3.12%2B-blueviolet)](https://bun.sh)
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,7 +1,5 @@
 [test]
 
-coverage = true
-
 coverageSkipTestFiles = true
 
 coveragePathIgnorePatterns = [

--- a/lib/ioc/Container.ts
+++ b/lib/ioc/Container.ts
@@ -139,8 +139,42 @@ export class Container {
     return this._services[key] !== undefined;
   }
 
-  public resolveStrategy<T>(key: string): Promise<T[] | null> {
-    return this.resolve<T>(key) as Promise<T[] | null>;
+  /**
+   * @description Resolve every implementation registered under a strategy key.
+   *
+   * Cardinality is normalized here rather than borrowed from resolve(). `_services[key]` has
+   * three shapes - absent, a bare ContainerService, an array - and resolve() maps them to
+   * throw / T / T[]. That is right for @Inject, whose dependency is single-valued: it is
+   * either there or the component is broken. @Strategy is multi-valued by construction, so
+   * zero is a cardinality it has to be able to take (a plugin point before its first plugin)
+   * and one has to arrive as a one-element array like any other count.
+   *
+   * This used to be a cast over resolve(), which made it correct at exactly one cardinality:
+   * an empty key aborted the boot, and a single implementation was injected as a bare
+   * instance whose first `.length` / `for...of` / `.map()` failed at runtime.
+   *
+   * @param {string} key - Strategy (interface) key
+   * @returns {Promise<T[]>} Every implementation, empty when the key has none
+   */
+  public async resolveStrategy<T>(key: string): Promise<T[]> {
+    // Kept from resolve(): a cycle running through a strategy key must still be reported
+    // rather than recursing until the stack overflows
+    this.circularDetector.checkCircular(key);
+    this.circularDetector.push(key);
+
+    try {
+      const service = this._services[key];
+
+      if (!service) {
+        return [];
+      }
+
+      return Array.isArray(service)
+        ? await this.resolveMultipleContainerService<T>(service)
+        : [await this.resolveContainerService<T>(service)];
+    } finally {
+      this.circularDetector.pop(key);
+    }
   }
 
   /**

--- a/lib/ioc/IocEngine.ts
+++ b/lib/ioc/IocEngine.ts
@@ -64,6 +64,8 @@ export class IocEngine implements ICoreService {
     // load components
     await this.loadComponents(components);
 
+    this.reportEmptyStrategyKeys();
+
     const injectableClasses = this.injectables.map((c) => c.Class);
 
     // Two-phase registration for PostProcessor support
@@ -656,6 +658,78 @@ export class IocEngine implements ICoreService {
       return [...new Set([...directDependencies, ...softDependencies])];
     } catch {
       return [];
+    }
+  }
+
+  /**
+   * Every strategy key a component consumes, keyed by the field that declares it. Walks the
+   * prototype chain like getStrategyDependencies does - a @Strategy field on a base class is
+   * injected into the subclass too, so it has to be reported against the subclass. Own class
+   * first, so a field redeclared in a subclass wins the same way injection resolves it.
+   */
+  private collectStrategyFields(component: Class): Map<string, string> {
+    const fields = new Map<string, string>();
+
+    const own = getOwnTypedMetadata<Strategies>(ComponentConstants.StrategyKey, component);
+
+    for (const [field, key] of Object.entries(own ?? {})) {
+      if (typeof key === 'string' && key) {
+        fields.set(field, key);
+      }
+    }
+
+    const parent = Object.getPrototypeOf(component);
+
+    if (typeof parent === 'function' && parent !== Function.prototype) {
+      for (const [field, key] of this.collectStrategyFields(parent)) {
+        if (!fields.has(field)) {
+          fields.set(field, key);
+        }
+      }
+    }
+
+    return fields;
+  }
+
+  /**
+   * Reports strategy keys nothing implements, once per injection site, at boot.
+   *
+   * An empty key is a legitimate plugin point and is injected as `[]`, which means a *typo'd*
+   * interface name no longer fails at boot either - it surfaces much later as a collection
+   * that is silently always empty. This line is what keeps the two apart.
+   *
+   * `debug` with no fallback to `info`, deliberately unlike the adapters' error handlers
+   * (`Ergenecore.respondToError`, `HonoAdapter`): there the line must not disappear, here a
+   * deliberate plugin point should stay quiet unless someone is looking.
+   */
+  private reportEmptyStrategyKeys(): void {
+    // Optional twice over: `debug` is optional on ServerLogger, and `logger` itself is absent
+    // whenever an IocEngine is built directly instead of through DI - which several suites do.
+    // A diagnostic must not be the thing that decides whether registration runs. The warn/error
+    // paths elsewhere stay unguarded, so genuinely broken wiring still fails loudly.
+    const debug = this.logger?.debug;
+
+    if (!debug) {
+      return;
+    }
+
+    const implemented = new Set(this.injectables.map((injectable) => injectable.interface).filter(Boolean));
+
+    for (const { Class: component } of this.injectables) {
+      const name = getTypedMetadata<string>(ComponentConstants.NameKey, component) || component.name;
+
+      for (const [field, key] of this.collectStrategyFields(component)) {
+        // A double seeded through `overrides` is a real implementation of that key - warning
+        // here would fire on every slice test that mocks a plugin point
+        if (implemented.has(key) || this._container.isOverridden(key)) {
+          continue;
+        }
+
+        debug.call(
+          this.logger,
+          `[IocEngine] Strategy key '${key}' has no implementations - ${name}.${field} will be injected as []`,
+        );
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asenajs/asena",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "author": "LibirSoft",
   "repository": {
     "type": "git",

--- a/test/ioc/StrategyCardinality.test.ts
+++ b/test/ioc/StrategyCardinality.test.ts
@@ -1,0 +1,411 @@
+import { describe, expect, test } from 'bun:test';
+import { Container, IocEngine } from '../../lib/ioc';
+import { Component, Service } from '../../lib/server/decorators';
+import { Implements, Inject, Strategy } from '../../lib/ioc/component';
+import type { Class } from '../../lib/server/types';
+
+/**
+ * `@Strategy` is multi-valued by construction - that is the whole difference from `@Inject`.
+ * It was correct at exactly one cardinality.
+ *
+ *   0 implementations -> `resolve()` threw "<key> is not registered" and the boot died
+ *   1 implementation  -> the field got a BARE INSTANCE, not `[instance]`
+ *   1 + expression    -> reading the field threw "strategy.map is not a function"
+ *   2+ implementations-> correct
+ *
+ * One root cause. `Container.register()` stores a key's first registration as a bare
+ * `ContainerService` and only converts to an array on the second, so `_services[key]` has three
+ * shapes - undefined / object / array - which `resolve()` maps to throw / T / T[]. Right for
+ * `@Inject`, whose dependency is single-valued and either present or the component is broken.
+ * `resolveStrategy` was a cast over that same lookup (`as Promise<T[] | null>`), so it declared
+ * `T[]` for all three.
+ *
+ * The 1-implementation case was the dangerous one: 0 died loudly at boot, 1 passed boot and
+ * failed later at the first `.length` / `for...of` / `.map()`. Worse, the bug disappears as you
+ * add implementations - write the registry (boot dies), add the first plugin (silently wrong),
+ * add the second (suddenly works) - so it "fixes itself" and is never diagnosed.
+ *
+ * Why nothing caught it, in order of how much each contributed:
+ *
+ * 1. Both existing strategy tests use exactly TWO implementations (`Container.test.ts`,
+ *    'should inject strategy' and 'should getStrategy components'). They pinned the only
+ *    cardinality that worked - not covering the bug, but certifying an accuracy that did not
+ *    exist.
+ * 2. Every documented example uses two as well (`Website/docs/concepts/dependency-injection.md`,
+ *    the `@Strategy` section). The feature is named for the plural case, so the singular and
+ *    empty cases were in nobody's mental model - not the author's, not the reviewer's.
+ * 3. The type system was silenced by hand. `resolveStrategy`'s cast declared all three shapes
+ *    as `T[]`, and `injectStrategies` received it as `Class[]`. Nothing could warn.
+ * 4. The layer above already tolerated zero. `getStrategyClass` (`helper/iocHelper.ts`) returns
+ *    `[]` for a key nothing implements and the topological sort handles it fine - `Container`
+ *    was the only layer that refused, so the refusal read like a deliberate strictness rule.
+ * 5. The error message did not distinguish two causes. `"<key> is not registered"` is also what
+ *    a component resolved before its implementations produces (see the recursion comment in
+ *    `IocEngine.getStrategyDependencies`), so the trace pointed at an ordering bug.
+ *
+ * The gap was found by booting a real application, not by testing - which is why layer B here
+ * drives a real `IocEngine`, and why a full `bun src/index.ts` boot was used to verify the fix.
+ */
+
+// --- Layer A fixtures: plain Container ------------------------------------------------------
+
+interface Tool {
+  name: string;
+}
+
+@Component()
+class AlphaTool implements Tool {
+  public name = 'alpha';
+}
+
+@Component()
+class BetaTool implements Tool {
+  public name = 'beta';
+}
+
+@Component()
+class Consumer {
+  @Strategy('ToolIface')
+  public tools: Tool[];
+}
+
+@Component()
+class ExprConsumer {
+  @Strategy('ToolIface', (tool: Tool) => tool.name)
+  public names: string[];
+}
+
+/** Registers `impls` under the strategy key, then both consumers. */
+const containerWith = async (...impls: Class[]): Promise<Container> => {
+  const container = new Container();
+
+  for (const impl of impls) {
+    await container.register('ToolIface', impl, true);
+  }
+
+  await container.register('Consumer', Consumer, true);
+  await container.register('ExprConsumer', ExprConsumer, true);
+
+  return container;
+};
+
+const consumerOf = async (container: Container): Promise<Consumer> => (await container.resolve('Consumer')) as Consumer;
+
+const exprConsumerOf = async (container: Container): Promise<ExprConsumer> =>
+  (await container.resolve('ExprConsumer')) as ExprConsumer;
+
+describe('Container - @Strategy cardinality', () => {
+  describe('0 implementations', () => {
+    test('should inject an empty array instead of aborting the boot', async () => {
+      // A plugin point with no plugins is the ordinary starting condition of one: the registry
+      // is written first, implementations arrive per feature.
+      const container = await containerWith();
+
+      expect((await consumerOf(container)).tools).toEqual([]);
+    });
+
+    test('should inject an empty array through an expression too', async () => {
+      const container = await containerWith();
+
+      expect((await exprConsumerOf(container)).names).toEqual([]);
+    });
+
+    test('should resolve the key to [] rather than throwing', async () => {
+      const container = await containerWith();
+
+      expect(await container.resolveStrategy('ToolIface')).toEqual([]);
+    });
+  });
+
+  describe('1 implementation', () => {
+    test('should inject a one-element array, not the bare instance', async () => {
+      // The silent half of the bug: boot passed and the field held an object, so the first
+      // `.length` / `for...of` / `.map()` failed at runtime, far from the cause.
+      const container = await containerWith(AlphaTool);
+
+      const { tools } = await consumerOf(container);
+
+      expect(Array.isArray(tools)).toBe(true);
+      expect(tools).toHaveLength(1);
+      expect(tools[0]).toBeInstanceOf(AlphaTool);
+    });
+
+    test('should be iterable with one implementation', async () => {
+      const container = await containerWith(AlphaTool);
+
+      const collected: string[] = [];
+
+      for (const tool of (await consumerOf(container)).tools) {
+        collected.push(tool.name);
+      }
+
+      expect(collected).toEqual(['alpha']);
+    });
+
+    test('should apply the expression instead of throwing on property access', async () => {
+      // Previously threw "strategy.map is not a function" from inside the injected getter -
+      // a `.map()` the application never wrote.
+      const container = await containerWith(AlphaTool);
+
+      expect((await exprConsumerOf(container)).names).toEqual(['alpha']);
+    });
+
+    test('should resolve the key to a one-element array', async () => {
+      const container = await containerWith(AlphaTool);
+
+      expect(await container.resolveStrategy('ToolIface')).toHaveLength(1);
+    });
+  });
+
+  describe('2 implementations', () => {
+    test('should inject every implementation', async () => {
+      const container = await containerWith(AlphaTool, BetaTool);
+
+      expect((await consumerOf(container)).tools.map((tool) => tool.name)).toEqual(['alpha', 'beta']);
+    });
+
+    test('should apply the expression to every implementation', async () => {
+      const container = await containerWith(AlphaTool, BetaTool);
+
+      expect((await exprConsumerOf(container)).names).toEqual(['alpha', 'beta']);
+    });
+
+    test('should resolve the key to a two-element array', async () => {
+      const container = await containerWith(AlphaTool, BetaTool);
+
+      expect(await container.resolveStrategy('ToolIface')).toHaveLength(2);
+    });
+  });
+});
+
+// --- Circular detection ---------------------------------------------------------------------
+
+@Component()
+class SelfStrategy {
+  @Strategy('SelfIface')
+  public peers: SelfStrategy[];
+}
+
+describe('Container.resolveStrategy - circular detection', () => {
+  test('should leave the resolution stack empty so the key can be resolved again', async () => {
+    // resolveStrategy used to inherit push/pop from resolve(). A dedicated lookup that pushes
+    // without popping would leave the key on the stack and report the SECOND call as a cycle.
+    const container = await containerWith(AlphaTool);
+
+    await container.resolveStrategy('ToolIface');
+    await container.resolveStrategy('ToolIface');
+
+    expect((container as any).circularDetector.isEmpty()).toBe(true);
+  });
+
+  test('should detect a cycle that runs through the strategy key itself', async () => {
+    // Entered under the component name, so the strategy key is only ever pushed by
+    // resolveStrategy. Without that push this recurses until the stack overflows.
+    const container = new Container();
+
+    await container.register('SelfStrategy', SelfStrategy, false);
+    await container.register('SelfIface', SelfStrategy, false);
+
+    expect(container.resolve('SelfStrategy')).rejects.toThrow(/Circular dependency detected/);
+  });
+});
+
+// --- Overrides ------------------------------------------------------------------------------
+
+describe('Container.overrideInstance on a strategy key', () => {
+  test('should inject a single override as a one-element array', async () => {
+    // overrideInstance always writes the bare-object shape, so mocking a strategy key in a
+    // slice test produced the same cardinality-1 bug through the public testing API.
+    const container = new Container();
+    const double: Tool = { name: 'double' };
+
+    container.overrideInstance('ToolIface', double);
+    await container.register('Consumer', Consumer, true);
+
+    expect((await consumerOf(container)).tools).toEqual([double]);
+  });
+});
+
+// --- Layer B fixtures: real IocEngine registration -------------------------------------------
+
+@Service()
+@Implements('AgentTool')
+class SearchTool implements Tool {
+  public name = 'search';
+}
+
+@Service()
+@Implements('AgentTool')
+class CalcTool implements Tool {
+  public name = 'calc';
+}
+
+/** A subclass of an implementation joins its base's key - @Implements is inherited as of 0.9.0. */
+@Service()
+class DerivedSearchTool extends SearchTool {
+  public override name = 'derived';
+}
+
+@Service('ToolRegistry')
+class ToolRegistry {
+  @Strategy('AgentTool')
+  public handlers: Tool[];
+}
+
+class StrategyBase {
+  @Strategy('AgentTool')
+  public inherited: Tool[];
+}
+
+@Service('DerivedRegistry')
+class DerivedRegistry extends StrategyBase {}
+
+const engineWith = () => {
+  const engine = new IocEngine();
+  const debugLines: string[] = [];
+
+  (engine as any)['_container'] = new Container();
+  (engine as any)['logger'] = {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    profile: () => {},
+    debug: (message: string) => debugLines.push(message),
+  };
+
+  return { engine, debugLines };
+};
+
+const registryFrom = async (engine: IocEngine, name = 'ToolRegistry'): Promise<any> =>
+  await engine.container.resolve(name);
+
+describe('IocEngine - @Strategy cardinality end to end', () => {
+  test('should register a consumer whose strategy key has no implementations', async () => {
+    const { engine } = engineWith();
+
+    await engine.searchAndRegister([{ Class: ToolRegistry, interface: undefined }]);
+
+    expect((await registryFrom(engine)).handlers).toEqual([]);
+  });
+
+  test('should inject a one-element array for a single implementation', async () => {
+    const { engine } = engineWith();
+
+    await engine.searchAndRegister([
+      { Class: ToolRegistry, interface: undefined },
+      { Class: SearchTool, interface: 'AgentTool' },
+    ]);
+
+    const { handlers } = await registryFrom(engine);
+
+    expect(Array.isArray(handlers)).toBe(true);
+    expect(handlers.map((handler: Tool) => handler.name)).toEqual(['search']);
+  });
+
+  test('should inject every implementation for two', async () => {
+    const { engine } = engineWith();
+
+    await engine.searchAndRegister([
+      { Class: ToolRegistry, interface: undefined },
+      { Class: SearchTool, interface: 'AgentTool' },
+      { Class: CalcTool, interface: 'AgentTool' },
+    ]);
+
+    // Sorted: registration order is the topological sort's, not the argument list's
+    expect((await registryFrom(engine)).handlers.map((handler: Tool) => handler.name).sort()).toEqual([
+      'calc',
+      'search',
+    ]);
+  });
+
+  test('should inject [] for a @Strategy declared on a base class', async () => {
+    const { engine } = engineWith();
+
+    await engine.searchAndRegister([{ Class: DerivedRegistry, interface: undefined }]);
+
+    expect((await registryFrom(engine, 'DerivedRegistry')).inherited).toEqual([]);
+  });
+
+  test('should count a subclass that inherits @Implements', async () => {
+    const { engine } = engineWith();
+
+    await engine.searchAndRegister([
+      { Class: ToolRegistry, interface: undefined },
+      { Class: DerivedSearchTool, interface: 'AgentTool' },
+    ]);
+
+    expect((await registryFrom(engine)).handlers.map((handler: Tool) => handler.name)).toEqual(['derived']);
+  });
+});
+
+describe('IocEngine - empty strategy key diagnostic', () => {
+  test('should report a strategy key that nothing implements', async () => {
+    // The cost of the fix: an empty key is now silently `[]`, so a typo'd interface name fails
+    // much later and much further from the cause. This line keeps the diagnosis.
+    const { engine, debugLines } = engineWith();
+
+    await engine.searchAndRegister([{ Class: ToolRegistry, interface: undefined }]);
+
+    expect(debugLines.some((line) => line.includes('AgentTool') && line.includes('ToolRegistry'))).toBe(true);
+  });
+
+  test('should stay silent once the key has an implementation', async () => {
+    const { engine, debugLines } = engineWith();
+
+    await engine.searchAndRegister([
+      { Class: ToolRegistry, interface: undefined },
+      { Class: SearchTool, interface: 'AgentTool' },
+    ]);
+
+    expect(debugLines.filter((line) => line.includes('AgentTool'))).toHaveLength(0);
+  });
+
+  test('should stay silent when the key is supplied by an override', async () => {
+    // A test double is a legitimate implementation - warning here would fire on every slice test.
+    const { engine, debugLines } = engineWith();
+
+    engine.container.overrideInstance('AgentTool', { name: 'double' });
+
+    await engine.searchAndRegister([{ Class: ToolRegistry, interface: undefined }]);
+
+    expect(debugLines.filter((line) => line.includes('AgentTool'))).toHaveLength(0);
+  });
+
+  test('should report a base class strategy key against the declaring class', async () => {
+    const { engine, debugLines } = engineWith();
+
+    await engine.searchAndRegister([{ Class: DerivedRegistry, interface: undefined }]);
+
+    expect(debugLines.some((line) => line.includes('AgentTool'))).toBe(true);
+  });
+});
+
+// --- Recorded, not endorsed -----------------------------------------------------------------
+
+@Component()
+class InjectConsumer {
+  @Inject('ToolIface')
+  public tool: Tool | Tool[];
+}
+
+describe('@Inject on a key with several implementations', () => {
+  test('should inject an array - recorded, not endorsed', async () => {
+    // The other end of the same root cause: `_services[key]` becomes an array on the second
+    // registration and `resolve()` hands it straight to a single-valued field, whose declared
+    // type (`Class | Class[]` in injectDependencies) admits it.
+    //
+    // Deliberately NOT changed here. Making @Inject throw on a multi-implementation key is the
+    // defensible behaviour, but it is a breaking change for anyone relying on the array today,
+    // and it belongs with its own migration note rather than inside a @Strategy bug fix.
+    const container = new Container();
+
+    await container.register('ToolIface', AlphaTool, true);
+    await container.register('ToolIface', BetaTool, true);
+    await container.register('InjectConsumer', InjectConsumer, true);
+
+    const { tool } = (await container.resolve('InjectConsumer')) as InjectConsumer;
+
+    expect(Array.isArray(tool)).toBe(true);
+    expect(tool).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

`@asenajs/asena` **0.9.0 → 0.9.1** (patch). Full detail in `CHANGELOG.md`.

`@Strategy` is multi-valued by construction — that is the whole difference from `@Inject`. It was correct at exactly one cardinality:

| implementations | before | now |
|---|---|---|
| 0 | boot aborted with `<key> is not registered` | injected as `[]` |
| 1 | field held a **bare instance**, not `[instance]` | injected as `[instance]` |
| 1, with an expression | reading the field threw `strategy.map is not a function` | expression applied |
| 2+ | correct | unchanged |

**One root cause.** `Container.register()` stores a key's first registration as a bare `ContainerService` and only converts to an array on the second, so `_services[key]` has three shapes — absent, object, array — which `resolve()` maps to throw / `T` / `T[]`. That is right for `@Inject`, whose dependency is single-valued: it is either there or the component is broken. `resolveStrategy` was a cast over that same lookup, so it declared `T[]` for all three.

The single-implementation case was the more dangerous half. Zero died loudly at boot; one passed boot and failed later at the first `.length`, `for...of` or `.map()`, far from the cause. And because the bug disappears as implementations are added — write the registry (boot dies), add the first plugin (silently wrong), add the second (suddenly works) — it tends to get "fixed" by accident and never diagnosed.

A strategy key with no implementations is a plugin point before its first plugin, which is the ordinary starting condition of one, not a misconfiguration. This also fixes mocking a strategy key through `createTestApp`'s `overrides`, which produced the same single-implementation shape.

## API note

`Container.resolveStrategy` is now `Promise<T[]>` instead of `Promise<T[] | null>`. The `null` half was never reachable — `resolve()` threw instead — so this narrows the type to what the method actually did. It has no callers outside core (`Container.ts:330` and the tests), and every dependent package declares `@asenajs/asena@^0.9.0`, which already resolves 0.9.1 — so no dependent needs a change.

## New diagnostic

Because an empty key is now silently `[]`, a typo'd interface name no longer fails at boot; it surfaces later as a collection that is always empty. `IocEngine` therefore logs, once per injection site at boot:

```
[IocEngine] Strategy key '<key>' has no implementations - <Component>.<field> will be injected as []
```

At `debug` level, so a deliberate plugin point stays quiet unless someone is looking. Keys supplied through `overrides` are not reported. If the logger has no `debug` method — it is optional on `ServerLogger` — the line is skipped rather than falling back to `console`: an application that omits `debug` has said it does not want debug output, and `console.debug` would ignore that and be unsuppressable.

## Housekeeping

- README version badge: 0.9.0 → 0.9.1.
- `bunfig.toml`: `coverage = true` removed, so `bun test` no longer computes coverage on every run. Use `bun test --coverage` when you want it.

## Test plan

- [x] `bun test` — **1016 pass, 0 fail** across 102 files (993 before, +23 new in `test/ioc/StrategyCardinality.test.ts`)
- [x] `bun run build` — clean `tsc`, 489 files in `dist/`
- [x] `bun run check` — **0 errors**, 274 pre-existing `no-explicit-any` warnings; prettier clean

`StrategyCardinality.test.ts` covers all three cardinalities twice over: layer A against a plain `Container`, layer B driving a real `IocEngine`. Layer B is deliberate — this bug was found by booting an application, not by a unit test, and the two existing strategy tests both used exactly two implementations, pinning the only cardinality that worked.

## Note for reviewers

Once merged and published, `Website` PR [docs(di): @Strategy cardinality] documents the new behaviour. **That one must not merge before 0.9.1 is on npm** — the site deploys on push to master with no gate, and at 0.9.0 it went live describing a version nobody could install yet.
