### PR TITLE
release-v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,101 @@
 # @asenajs/asena
 
+## 0.10.0
+
+### Minor Changes
+
+- Component lifecycle: `@OnStart` and `@OnStop`, run by the server rather than the container
+
+  `@PostConstruct` used to run inside `Container.register()`, in the middle of the component scan.
+  That put a component's initialisation in a half-built graph, before the microservice transports
+  existed — and it had no counterpart, so nothing the hook acquired was ever released. Every
+  framework package that opens a connection leaked it past `server.stop()`.
+
+  Both halves now live in a `LifecycleService` driven by `start()` and `stop()`.
+
+  **`@OnStart`** is the new name for `@PostConstruct`, which remains as a deprecated alias writing
+  the same metadata key — no migration needed beyond the import. It runs during `server.start()`,
+  after every component is constructed and after application setup, but **before the HTTP socket
+  binds**: a hook can now publish through `ulak`, and no request can reach a component whose hook
+  has not run. Hooks run in registration order, which is the topological order the IoC engine
+  computed, so dependencies start first.
+
+  **`@OnStop`** is new. It runs during `server.stop()` in the reverse order, with the HTTP surface
+  already down and the transports still up, so a component can finish in-flight work and publish a
+  last message. A hook that throws or exceeds its timeout is logged and skipped — one component
+  failing to let go must not strand the rest. Only components whose start hook completed are
+  stopped.
+
+  **Breaking:**
+
+  - Start hooks no longer run during registration. A component resolved from a server that was
+    created but never started is no longer initialised.
+  - A failing start hook no longer calls `process.exit(1)`. It throws, naming the hook, with the
+    original error as `cause`, and `start()` rejects. That is what turned one broken component
+    into a suite reporting `0 pass / 1 fail` with no indication of why.
+  - `SIGTERM`, `SIGINT` and `SIGHUP` are handled by default and translated into `stop()`. Pass
+    `shutdown: { signals: false }` to own them yourself.
+
+  `@PostProcessor` components keep the old construction-time timing, because `postProcess()` reads
+  what their own start hook sets up.
+
+  Also in this release:
+
+  - `stop()` takes `{ closeActiveConnections, drainTimeout, hookTimeout }`; the boolean form still
+    works. `drainTimeout` was previously unreachable from `stop()` even though both broker
+    transports supported it. The sequence is contained step by step, so one failure cannot strand
+    the steps behind it, and `ulak.dispose()` is now called for you.
+  - `shutdown` and `keepAlive` options on the factory. `keepAlive` holds the event loop open for a
+    headless process, so a worker component can start its loop in `@OnStart`, return, and have the
+    process stay alive — the entry file no longer has to block on it.
+  - `server.resolve(name)`, the same signature the test harness exposes as `app.resolve()`.
+  - The headless health endpoint now serves `{path}/live` and `{path}/ready` alongside `{path}`.
+    Readiness is wired to the lifecycle state and the health server outlives the drain, so
+    `/ready` answers 503 for the whole shutdown rather than for the instant before the process
+    exits.
+  - Assigning to an `@Inject` or `@Strategy` field now names the field and the class and points at
+    `overrides` / `mockComponent()`, instead of the engine's bare "Attempted to assign to readonly
+    property."
+
+### Patch Changes
+
+- Add `HttpException` to `@asenajs/asena/adapter`, so both adapters throw one class
+
+  Until now each adapter declared its own. `@asenajs/ergenecore` exported an `HttpException` taking
+  `(status, body, options)`; `@asenajs/hono-adapter` re-exported `HTTPException` from
+  `hono/http-exception`, taking `(status, { message })`. Two classes, two constructors, two response
+  bodies for the same intent - so an application could not move between adapters, and the
+  documentation could not show one example.
+
+  The class now lives in core and both adapters accept it:
+
+  ```typescript
+  import { HttpException } from '@asenajs/asena/adapter';
+
+  throw new HttpException(404, { error: 'User not found' });
+  ```
+
+  `import { HttpException } from '@asenajs/ergenecore'` still works and resolves to the _same class
+  object_, so nothing breaks. `@asenajs/hono-adapter` deliberately does not re-export it - it
+  already exports hono's `HTTPException`, and two throwable classes differing by the case of two
+  letters is a trap for autocomplete. Hono's `HTTPException` remains fully supported, so
+  `hono/basic-auth`, `hono/bearer-auth`, `hono/jwt` and hono's own validator are unaffected.
+
+  `HttpExceptionLike` gains an optional `getResponse?: () => Response`. The brand only ever
+  guaranteed `status`, and both adapters called `getResponse()` on anything branded - a foreign
+  exception carrying only the brand threw a `TypeError` from inside the error path, where nothing
+  can catch it. Declaring the member optional makes the capability check type-safe.
+
+  **Branch on `isHttpException`, not `instanceof`.** This release makes that advice stronger rather
+  than weaker: `@asenajs/asena` is a peer dependency of every adapter, so two resolved copies now
+  produce two `HttpException` classes exactly as two adapter copies used to. The registered-symbol
+  brand crosses copies; `instanceof` does not.
+
+  Released as a patch on purpose. A new export would ordinarily be a minor, but eight packages
+  declare `@asenajs/asena: ^0.9.0` - a caret range on a 0.x version does not cross to `0.10.0`, and
+  core is published first, so a minor would make every one of them uninstallable the moment it hit
+  npm.
+
 ## 0.9.1
 
 ### Patch Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@
 
   **`@OnStart`** is the new name for `@PostConstruct`, which remains as a deprecated alias writing
   the same metadata key — no migration needed beyond the import. It runs during `server.start()`,
-  after every component is constructed and after application setup, but **before the HTTP socket
-  binds**: a hook can now publish through `ulak`, and no request can reach a component whose hook
-  has not run. Hooks run in registration order, which is the topological order the IoC engine
-  computed, so dependencies start first.
+  once every component is constructed and **before application setup**, so a `@Config` reading
+  its own injected dependencies — building a microservice transport from an injected service, the
+  pattern the redis and kafka packages document — finds them started. It is also long before the
+  HTTP socket binds, so no request can reach a component whose hook has not run. Hooks run in
+  registration order, which is the topological order the IoC engine computed, so dependencies
+  start first.
+
+  As in `0.9.x`, `ulak.send`/`emit` still cannot be used from a start hook: the transports are
+  wired during application setup, which is after this point.
 
   **`@OnStop`** is new. It runs during `server.stop()` in the reverse order, with the HTTP surface
   already down and the transports still up, so a component can finish in-flight work and publish a

--- a/README.md
+++ b/README.md
@@ -40,6 +40,42 @@ asena dev start
 
 Visit [asena.sh/docs/get-started](https://asena.sh/docs/get-started) for detailed setup instructions.
 
+## Component Lifecycle
+
+A component can take part in the server's start and stop:
+
+```typescript
+@Service()
+export class OutboxWorker {
+  @OnStart()
+  public start(): void {
+    // Runs during server.start(), after every component is constructed and after the
+    // microservice transports are connected - but before the HTTP socket binds, so no
+    // request can reach a component that has not run yet.
+    this.running = true;
+    this.loop = this.run(); // start it and return; do not block here
+  }
+
+  @OnStop()
+  public async stop(): Promise<void> {
+    // Runs during server.stop(), in the reverse order, so this component still has its
+    // dependencies while it lets go of its own.
+    this.running = false;
+    await this.loop;
+  }
+}
+```
+
+`@OnStart` is the new name for `@PostConstruct`, which remains as a deprecated alias writing the
+same metadata — existing code keeps working. Hooks run in registration order, which is the
+topological order the container computed, so dependencies start first and stop last. A failing
+`@OnStart` aborts the boot and rolls back what had already started; a failing or hanging `@OnStop`
+is logged and skipped so the rest of the shutdown still runs.
+
+`SIGTERM`, `SIGINT` and `SIGHUP` are handled by default and translated into `server.stop()`, so a
+rolling deploy drains rather than kills. See
+[asena.sh/docs/concepts/lifecycle](https://asena.sh/docs/concepts/lifecycle).
+
 ## Performance
 
 Built on Bun runtime for exceptional performance:

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ A component can take part in the server's start and stop:
 export class OutboxWorker {
   @OnStart()
   public start(): void {
-    // Runs during server.start(), after every component is constructed and after the
-    // microservice transports are connected - but before the HTTP socket binds, so no
-    // request can reach a component that has not run yet.
+    // Runs during server.start(), once every component is constructed and before the
+    // application is wired up - so a @Config finds its dependencies started - and long
+    // before the HTTP socket binds, so no request can reach a component that has not run.
     this.running = true;
     this.loop = this.run(); // start it and return; do not block here
   }

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,5 @@
 export { AsenaServerFactory, AsenaServer } from './lib/server';
+// Typing a stop() call or a shutdown config, and reading the state the readiness probe reports,
+// all need these. They shipped with the lifecycle and were reachable through no export path.
+export { LifecycleState } from './lib/server';
+export type { AsenaStopOptions, ShutdownOptions } from './lib/server';

--- a/lib/adapter/types/HttpException.ts
+++ b/lib/adapter/types/HttpException.ts
@@ -1,3 +1,5 @@
+import type { HttpStatusCode } from '../../server/web/types';
+
 /**
  * Brand used instead of `instanceof`.
  *
@@ -7,21 +9,20 @@
  * of them. Every deliberate 401/403/404/429 then collapses to a generic 500, and the API still
  * responds, so nothing looks broken.
  *
- * The hono adapter is the more exposed of the two: its base is `HTTPException` from
- * `hono/http-exception`, which the adapter carries as a regular *dependency*. An application that
- * also depends on `hono` directly - the ordinary case, since that is where `HTTPException` is
- * documented - can therefore resolve a second copy, which makes two `hono` copies considerably
- * more likely than two copies of the adapter. Note the brand cannot help there: it is installed on
- * the prototype of the copy the adapter resolved and cannot reach another copy's class. Import
- * `HTTPException` from `@asenajs/hono-adapter` to stay on one copy.
- *
- * `ValidationError` and the removed `NotFoundError` were branded from the start; the base class
- * users actually throw was not. This closes that gap.
+ * The brand still matters now that the class below lives in core rather than in each adapter:
+ * two copies of `@asenajs/asena` produce two `HttpException` classes just as two copies of an
+ * adapter used to. It also covers the exception types this package does not own - the hono
+ * adapter brands `HTTPException` from `hono/http-exception` onto its prototype, so an exception
+ * thrown by `hono/basic-auth` or any other hono middleware answers to `isHttpException()` too.
  */
 export const HTTP_EXCEPTION = Symbol.for('asena.httpException');
 
 /**
  * @description The contract every adapter's HTTP exception satisfies.
+ *
+ * Implemented by {@link HttpException} below, and by exception types Asena does not own -
+ * hono's `HTTPException`, which the hono adapter brands so it answers to the same guard.
+ * An adapter dispatching on this interface therefore handles both without knowing which it has.
  */
 export interface HttpExceptionLike extends Error {
   readonly [HTTP_EXCEPTION]: true;
@@ -29,15 +30,24 @@ export interface HttpExceptionLike extends Error {
   /**
    * HTTP status code the exception should be answered with.
    *
-   * Only `status` is in the contract. Ergenecore's exception carries a structured `body`,
-   * Hono's carries a `message` and a `getResponse()` - `status` is the part both agree on and
-   * the part an adapter-agnostic handler can actually use.
+   * The one member every branded exception is guaranteed to carry. Foreign exception types
+   * satisfy this and little else, which is why an adapter falling back to its default response
+   * must be able to answer from `status` alone.
    */
   readonly status: number;
+
+  /**
+   * The response this exception answers with, when it can build one.
+   *
+   * Optional because the brand does not imply it: hono's `HTTPException` and Asena's own
+   * `HttpException` both provide it, but a foreign class carrying only the brand and a status
+   * is still a valid {@link HttpExceptionLike}. Adapters must check before calling.
+   */
+  readonly getResponse?: () => Response;
 }
 
 /**
- * @description Whether an error is an adapter HTTP exception.
+ * @description Whether an error is an HTTP exception.
  *
  * Prefer this over `error instanceof HttpException` in `ConfigService.onError`:
  * ```typescript
@@ -49,7 +59,129 @@ export interface HttpExceptionLike extends Error {
  * }
  * ```
  * @param {unknown} error - The error to test
- * @returns {boolean} True when the error is an adapter HTTP exception
+ * @returns {boolean} True when the error is an HTTP exception
  */
 export const isHttpException = (error: unknown): error is HttpExceptionLike =>
   typeof error === 'object' && error !== null && (error as Record<symbol, unknown>)[HTTP_EXCEPTION] === true;
+
+/**
+ * Extended ResponseInit with cause support
+ */
+export interface HttpExceptionInit extends ResponseInit {
+  /** The original error that caused this exception */
+  cause?: Error;
+}
+
+/**
+ * HTTP Exception
+ *
+ * The single class to throw for a deliberate HTTP error, on every adapter. It lives in core
+ * rather than in each adapter so the same `throw` compiles and behaves identically whichever
+ * adapter the application runs on - previously ergenecore had its own class and the hono adapter
+ * re-exported hono's, with different constructor signatures and different response bodies, so
+ * moving an application between adapters meant rewriting every throw site.
+ *
+ * Building a `Response` needs nothing beyond the web globals, so this does not cost the package
+ * its zero-dependency rule.
+ *
+ * @example
+ * ```typescript
+ * // In middleware
+ * if (!user) {
+ *   throw new HttpException(401, 'Unauthorized', {
+ *     headers: { 'WWW-Authenticate': 'Bearer' }
+ *   });
+ * }
+ *
+ * // In handler
+ * if (!isValid) {
+ *   throw new HttpException(400, { error: 'Invalid data' });
+ * }
+ *
+ * // With cause
+ * try { await db.query(...) } catch (err) {
+ *   throw new HttpException(500, 'Database Error', { cause: err });
+ * }
+ * ```
+ */
+export class HttpException extends Error implements HttpExceptionLike {
+  /**
+   * Registered-symbol brand so `isHttpException()` works even when a project resolves two
+   * copies of this package - `instanceof` answers false across copies, silently.
+   */
+  public readonly [HTTP_EXCEPTION] = true as const;
+
+  /**
+   * HTTP status code
+   */
+  public readonly status: number;
+
+  /**
+   * Response body (can be string or object)
+   */
+  public readonly body: string | object;
+
+  /**
+   * Optional response init options (headers, statusText, cause, etc.)
+   */
+  public readonly options?: HttpExceptionInit;
+
+  /**
+   * Creates a new HttpException
+   *
+   * @param status - HTTP status code (e.g., 401, 403, 404) or HttpStatusCode enum value
+   * @param body - Response body (string or object to be JSON stringified)
+   * @param options - Optional HttpExceptionInit options (headers, statusText, cause, etc.)
+   *
+   * @example
+   * ```typescript
+   * // Simple message
+   * throw new HttpException(404, 'Not Found');
+   *
+   * // With HttpStatusCode enum
+   * throw new HttpException(ClientErrorStatusCode.NotFound, 'Not Found');
+   *
+   * // JSON object
+   * throw new HttpException(400, { error: 'Invalid input', field: 'email' });
+   *
+   * // With headers
+   * throw new HttpException(429, 'Too Many Requests', {
+   *   headers: { 'Retry-After': '60' }
+   * });
+   *
+   * // With cause
+   * throw new HttpException(500, 'Internal Error', { cause: originalError });
+   * ```
+   */
+  public constructor(status: HttpStatusCode | number, body: string | object = '', options?: HttpExceptionInit) {
+    const message = typeof body === 'string' ? body : JSON.stringify(body);
+
+    super(message, options?.cause ? { cause: options.cause } : undefined);
+    this.name = 'HttpException';
+    this.status = status;
+    this.body = body;
+    this.options = options;
+  }
+
+  /**
+   * Converts the exception to a Response object
+   *
+   * @returns Response object ready to be returned
+   */
+  public getResponse(): Response {
+    const body = typeof this.body === 'string' ? this.body : JSON.stringify(this.body);
+
+    const headers = new Headers(this.options?.headers);
+
+    // Set Content-Type to application/json if body is an object and not already set
+    if (typeof this.body === 'object' && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+
+    return new Response(body, {
+      status: this.status,
+      statusText: this.options?.statusText,
+      headers,
+    });
+  }
+}

--- a/lib/ioc/Container.ts
+++ b/lib/ioc/Container.ts
@@ -5,12 +5,27 @@ import type {
   ContainerService,
   Dependencies,
   Expressions,
+  LifecycleComponent,
+  StartHookMode,
   Strategies,
 } from './types';
 import { ComponentConstants } from './constants';
 import { getOwnTypedMetadata, getTypedMetadata } from '../utils';
 import { CircularDependencyDetector } from './CircularDependencyDetector';
 import { CORE_SERVICE } from './decorators';
+
+/**
+ * The message behind an assignment to a wired field.
+ *
+ * Injected fields are installed as accessors with no setter, so assigning to one throws the
+ * engine's own `TypeError: Attempted to assign to readonly property.` - no field name, no class,
+ * no hint at what to do instead. Everybody reaches for `Object.assign(instance, {dep: fake})`
+ * once; this turns that minute into a sentence.
+ */
+const injectedFieldMessage = (Class: Class, field: string, decorator: string): string =>
+  `Cannot assign to '${field}' on ${Class.name}: fields wired by ${decorator} are read-only. ` +
+  "To swap a dependency in a test, use the 'overrides' option of createTestApp()/createWebTest(), " +
+  'or mockComponent().';
 
 export class Container {
   private _services: { [key: string]: ContainerService | ContainerService[] } = {};
@@ -20,6 +35,26 @@ export class Container {
   private postProcessors: ComponentPostProcessor[] = [];
 
   private overriddenKeys = new Set<string>();
+
+  /**
+   * Whether construction runs start hooks itself.
+   *
+   * `immediate` is the original behaviour and stays that way for core services, for the
+   * post-processor closure the IoC engine registers ahead of everything else, and for every
+   * transient. `deferred` holds the hooks back so `LifecycleService` can run them from
+   * `server.start()`, once the whole graph exists.
+   */
+  private startHookMode: StartHookMode = 'immediate';
+
+  /**
+   * Every singleton built by `register()`, in registration order - which the IoC engine has
+   * already topologically sorted, so dependencies come before dependents. Start hooks walk it
+   * forwards, stop hooks backwards.
+   *
+   * Instances handed in through `registerInstance()` are deliberately absent: nothing ever ran
+   * a start hook on them, so there is no started/stopped pair to keep symmetric.
+   */
+  private lifecycleComponents: LifecycleComponent[] = [];
 
   public constructor(services?: { [key: string]: ContainerService | ContainerService[] }) {
     this._services = services || {};
@@ -33,22 +68,47 @@ export class Container {
       return;
     }
 
+    const instance = singleton ? await this.prepareInstance(Class) : null;
+
+    if (singleton) {
+      this.trackLifecycle(key, instance, Class);
+    }
+
     if (this._services[key]) {
       if (Array.isArray(this._services[key])) {
-        this._services[key].push({ Class, instance: singleton ? await this.prepareInstance(Class) : null, singleton });
+        this._services[key].push({ Class, instance, singleton });
 
         return;
       }
 
-      this._services[key] = [
-        this._services[key],
-        { Class, instance: singleton ? await this.prepareInstance(Class) : null, singleton },
-      ];
+      this._services[key] = [this._services[key], { Class, instance, singleton }];
 
       return;
     }
 
-    this._services[key] = { Class, instance: singleton ? await this.prepareInstance(Class) : null, singleton };
+    this._services[key] = { Class, instance, singleton };
+  }
+
+  /**
+   * @description Record a singleton for the start/stop lifecycle.
+   *
+   * `started` reflects what already happened rather than what is planned: a component built in
+   * immediate mode has run its start hooks by the time it gets here, so it is stoppable at once.
+   * A deferred one is not started until `LifecycleService` says so - and a component that never
+   * started must never be stopped.
+   *
+   * @param {string} key - Service identifier
+   * @param {unknown} instance - The post-processed instance
+   * @param {Class} Class - The class it was built from
+   * @returns {void}
+   */
+  private trackLifecycle(key: string, instance: unknown, Class: Class): void {
+    this.lifecycleComponents.push({
+      key,
+      instance,
+      Class,
+      started: this.startHookMode === 'immediate',
+    });
   }
 
   /**
@@ -245,14 +305,34 @@ export class Container {
     this.postProcessors.push(processor);
   }
 
+  /**
+   * @description Choose whether construction runs start hooks or hands them to LifecycleService.
+   *
+   * The IoC engine switches to `deferred` around user components only. Post-processors keep
+   * running theirs at construction because `postProcess()` reads state a start hook sets - defer
+   * that and every component the processor wraps is built against an uninitialised processor.
+   *
+   * @param {StartHookMode} mode - immediate (default) or deferred
+   * @returns {void}
+   */
+  public setStartHookMode(mode: StartHookMode): void {
+    this.startHookMode = mode;
+  }
+
+  /**
+   * @description Singletons in registration order, for the start/stop lifecycle.
+   * @returns {LifecycleComponent[]} The live list - LifecycleService flips `started` on it
+   */
+  public get lifecycle(): LifecycleComponent[] {
+    return this.lifecycleComponents;
+  }
+
   private async prepareInstance<T>(Class: Class) {
     const newInstance = new Class();
 
     await this.injectDependencies(newInstance, Class); // dependency injection
 
     await this.injectStrategies(newInstance, Class); // strategy injection
-
-    await this.executePostConstructs(newInstance, Class); // post construct
 
     // Post-processing (skipped when postProcessors is empty - zero overhead)
     let processed: any = newInstance;
@@ -261,43 +341,92 @@ export class Container {
       processed = (await processor.postProcess(processed, Class)) ?? processed;
     }
 
+    // Deferred mode leaves the start hooks to LifecycleService. The hook runs against the
+    // *processed* instance either way - a post-processor may have returned a proxy, and the
+    // hook has to see the same object every other component was injected with.
+    if (this.startHookMode === 'immediate') {
+      await this.executeStartHooks(processed, Class);
+    }
+
     return processed as T;
   }
 
   /**
-   * @description Executes PostConstruct methods on the instance.
-   * Prevents duplicate execution of inherited methods by tracking executed method names.
-   * @param {any} newInstance - The instance to execute PostConstructs on
+   * @description Run every @OnStart (and its @PostConstruct alias) method on an instance.
+   *
+   * Walks the prototype chain ancestors-first and runs each method name once, so a hook
+   * inherited by three classes still fires once.
+   *
+   * A failure used to `process.exit(1)` here, which turned one broken component into a suite
+   * reporting `0 pass / 1 fail` with no indication of why. It now throws, naming the hook, with
+   * the original error as `cause` - the boot fails, the process decides what to do about it.
+   *
+   * @param {any} instance - The instance to run hooks on
    * @param {Class} Class - The class of the instance
    * @returns {Promise<void>}
    */
-  private async executePostConstructs(newInstance: any, Class: Class): Promise<void> {
+  public async executeStartHooks(instance: any, Class: Class): Promise<void> {
+    for (const hook of this.collectHookMethods(Class, ComponentConstants.PostConstructKey)) {
+      try {
+        await instance[hook]();
+      } catch (error) {
+        throw new Error(`@OnStart hook '${Class.name}.${hook}()' failed`, { cause: error });
+      }
+    }
+  }
+
+  /**
+   * @description The @OnStop method names for a class, in the order they should run.
+   *
+   * Reversed relative to the start hooks so a component tears down in the opposite order it
+   * was brought up, matching how LifecycleService walks the components themselves.
+   *
+   * @param {Class} Class - The class to inspect
+   * @returns {string[]} Method names, empty when the class declares none
+   */
+  public getStopHooks(Class: Class): string[] {
+    return this.collectHookMethods(Class, ComponentConstants.OnStopKey).reverse();
+  }
+
+  /**
+   * @description The @OnStart method names for a class, in the order they run.
+   * @param {Class} Class - The class to inspect
+   * @returns {string[]} Method names, empty when the class declares none
+   */
+  public getStartHooks(Class: Class): string[] {
+    return this.collectHookMethods(Class, ComponentConstants.PostConstructKey);
+  }
+
+  /**
+   * @description Collect decorated method names across the prototype chain, de-duplicated.
+   * @param {Class} Class - The class to inspect
+   * @param {symbol} metadataKey - Which hook list to read
+   * @returns {string[]} Method names, ancestors first
+   */
+  private collectHookMethods(Class: Class, metadataKey: symbol): string[] {
     const prototypeChain = this.getPrototypeChain(Class);
-    const executedMethods = new Set<string>();
+    const methods: string[] = [];
+    const seen = new Set<string>();
 
     for (const classInChain of prototypeChain.reverse()) {
-      const postConstructs: string[] = getOwnTypedMetadata<string[]>(ComponentConstants.PostConstructKey, classInChain);
+      const hooks: string[] = getOwnTypedMetadata<string[]>(metadataKey, classInChain);
 
-      if (!postConstructs) {
+      if (!hooks) {
         continue;
       }
 
-      for (const postConstruct of postConstructs) {
-        // Skip if already executed (prevents duplicate execution in inheritance chain)
-        if (executedMethods.has(postConstruct)) {
+      for (const hook of hooks) {
+        // Skip if already collected (prevents duplicate execution in inheritance chain)
+        if (seen.has(hook)) {
           continue;
         }
 
-        try {
-          await newInstance[postConstruct]();
-          executedMethods.add(postConstruct);
-        } catch (error) {
-          console.log('Error in post construct, exiting process');
-          console.error(error);
-          process.exit(1);
-        }
+        seen.add(hook);
+        methods.push(hook);
       }
     }
+
+    return methods;
   }
 
   private async injectStrategies(newInstance: any, Class: Class) {
@@ -337,6 +466,9 @@ export class Container {
         Object.defineProperty(newInstance, propertyKey, {
           get() {
             return expression?.[propertyKey] ? strategy.map((s) => expression[propertyKey](s)) : strategy;
+          },
+          set: () => {
+            throw new TypeError(injectedFieldMessage(Class, propertyKey, '@Strategy'));
           },
           enumerable: true,
           configurable: true,
@@ -378,6 +510,9 @@ export class Container {
         Object.defineProperty(newInstance, k, {
           get: () => {
             return expression?.[k] ? expression[k](instance) : instance;
+          },
+          set: () => {
+            throw new TypeError(injectedFieldMessage(Class, k, '@Inject'));
           },
           enumerable: true,
           configurable: true,

--- a/lib/ioc/CoreContainer.ts
+++ b/lib/ioc/CoreContainer.ts
@@ -16,6 +16,7 @@ import { Ulak } from '../server/messaging';
 import { EventDispatchService } from '../server/event';
 import { EventEmitter } from '../server/event';
 import { CronRunner } from '../server/schedule';
+import { LifecycleService } from '../server/lifecycle/LifecycleService';
 
 /**
  * @description CoreContainer manages framework-level services
@@ -152,6 +153,9 @@ export class CoreContainer {
       // Schedule system (CronRunner must be registered before PrepareScheduleService)
       { name: ICoreServiceNames.CRON_RUNNER, Class: CronRunner },
       { name: ICoreServiceNames.PREPARE_SCHEDULE_SERVICE, Class: PrepareScheduleService },
+
+      // Component start/stop hooks, driven by AsenaServer.start()/stop()
+      { name: ICoreServiceNames.LIFECYCLE_SERVICE, Class: LifecycleService },
     ];
 
     for (const service of services) {

--- a/lib/ioc/IocEngine.ts
+++ b/lib/ioc/IocEngine.ts
@@ -89,8 +89,20 @@ export class IocEngine implements ICoreService {
     }
 
     // Phase B: Register remaining components (post-processing is now active)
+    //
+    // Their start hooks are held back for LifecycleService to run from server.start(), so a
+    // hook sees the finished graph - and can reach the microservice transports, which are not
+    // connected until application setup. Phase A deliberately keeps the old timing: a
+    // post-processor's postProcess() reads what its own start hook set up, so deferring it
+    // would wrap every component in Phase B against an uninitialised processor.
     if (remainingClasses.length > 0) {
-      await this.validateAndRegisterComponents(remainingClasses);
+      this._container.setStartHookMode('deferred');
+
+      try {
+        await this.validateAndRegisterComponents(remainingClasses);
+      } finally {
+        this._container.setStartHookMode('immediate');
+      }
     }
   }
 
@@ -263,6 +275,10 @@ export class IocEngine implements ICoreService {
 
       const isSingleton = getTypedMetadata<Scope>(ComponentConstants.ScopeKey, injectable) === Scope.SINGLETON;
 
+      if (!isSingleton) {
+        this.warnAboutTransientLifecycleHooks(name, injectable);
+      }
+
       await this._container.register(name, injectable, isSingleton);
 
       const _interface = getTypedMetadata<string>(ComponentConstants.InterfaceKey, injectable);
@@ -273,6 +289,35 @@ export class IocEngine implements ICoreService {
         await this._container.register(_interface, injectable, isSingleton);
       }
     }
+  }
+
+  /**
+   * @description Warn when a transient declares lifecycle hooks.
+   *
+   * A transient is constructed per resolve and the container keeps no handle on it, so there is
+   * nothing for the server to start or stop. Its @OnStart still runs at construction, but its
+   * @OnStop can never run - and a component that acquires something it never releases is worth
+   * saying out loud rather than leaving to be discovered as a leak.
+   *
+   * @param {string} name - Registered component name
+   * @param {Class} injectable - The component class
+   * @returns {void}
+   */
+  private warnAboutTransientLifecycleHooks(name: string, injectable: Class): void {
+    // The container's own walk, not a metadata read: it is the one that de-duplicates an
+    // inherited hook and stops at native code, so the two can never disagree about what would
+    // have run.
+    const stopHooks = this._container.getStopHooks(injectable);
+
+    if (stopHooks.length === 0) {
+      return;
+    }
+
+    this.logger.warn(
+      `[IocEngine] '${name}' is transient and declares @OnStop (${stopHooks.join(', ')}), which will never ` +
+        'run - the container keeps no handle on a transient instance. Make it a singleton, or release the ' +
+        'resource where it is used.',
+    );
   }
 
   private async getInjectables(files: string[]): Promise<InjectableComponent[]> {

--- a/lib/ioc/component/decorators/OnStart.ts
+++ b/lib/ioc/component/decorators/OnStart.ts
@@ -1,0 +1,36 @@
+import { ComponentConstants } from '../../constants';
+import { defineTypedMetadata, getOwnTypedMetadata } from '../../../utils/typedMetadata';
+
+/**
+ * A decorator that marks a method to be called when the server starts.
+ *
+ * Runs during `server.start()`, after every component has been constructed and after the
+ * application setup phase - configs are read, microservice transports are connected and
+ * listening, routes are registered - but *before* the HTTP socket is bound. So a hook may
+ * publish through `ulak`, and no request can arrive at a component that has not run yet.
+ *
+ * Hooks run in registration order, which is the topological order the IoC engine computed:
+ * a component's dependencies have already started when its own hook runs. A throwing hook
+ * aborts the boot and rolls back the components that already started.
+ *
+ * The hook must return. A component that runs for the process's lifetime should start its
+ * loop here and keep the handle for {@link OnStop} - an `@OnStart` that never resolves is a
+ * server that never finishes starting.
+ *
+ * Only singletons take part; a transient is constructed per resolve and has no lifecycle to
+ * hang a start hook on.
+ *
+ * @returns {PropertyDecorator} The property decorator function.
+ */
+export const OnStart = (): PropertyDecorator => {
+  return (target: object, propertyKey: string): void => {
+    const hooks: string[] =
+      getOwnTypedMetadata<string[]>(ComponentConstants.PostConstructKey, target.constructor) || [];
+
+    if (!hooks.includes(propertyKey)) {
+      hooks.push(propertyKey);
+    }
+
+    defineTypedMetadata<string[]>(ComponentConstants.PostConstructKey, hooks, target.constructor);
+  };
+};

--- a/lib/ioc/component/decorators/OnStop.ts
+++ b/lib/ioc/component/decorators/OnStop.ts
@@ -1,0 +1,30 @@
+import { ComponentConstants } from '../../constants';
+import { defineTypedMetadata, getOwnTypedMetadata } from '../../../utils/typedMetadata';
+
+/**
+ * A decorator that marks a method to be called when the server stops.
+ *
+ * The counterpart to {@link OnStart}. Runs during `server.stop()`, in the reverse of start
+ * order, so a component still has its dependencies while it releases its own resources. The
+ * HTTP surface is already down by then and the microservice transports are still up, which
+ * makes this the place to finish in-flight work and publish a last message.
+ *
+ * A hook that throws or exceeds the shutdown timeout is logged and skipped - shutdown
+ * continues. One component failing to let go must not strand the rest.
+ *
+ * Only components whose start hook completed are stopped. A `stop()` on a server that never
+ * started, or that failed during boot, runs nothing that never ran.
+ *
+ * @returns {PropertyDecorator} The property decorator function.
+ */
+export const OnStop = (): PropertyDecorator => {
+  return (target: object, propertyKey: string): void => {
+    const hooks: string[] = getOwnTypedMetadata<string[]>(ComponentConstants.OnStopKey, target.constructor) || [];
+
+    if (!hooks.includes(propertyKey)) {
+      hooks.push(propertyKey);
+    }
+
+    defineTypedMetadata<string[]>(ComponentConstants.OnStopKey, hooks, target.constructor);
+  };
+};

--- a/lib/ioc/component/decorators/PostConstruct.ts
+++ b/lib/ioc/component/decorators/PostConstruct.ts
@@ -1,20 +1,16 @@
-import { ComponentConstants } from '../../constants';
-import { defineTypedMetadata, getOwnTypedMetadata } from '../../../utils/typedMetadata';
+import { OnStart } from './OnStart';
 
 /**
  * A decorator that marks a method to be called after the component's construction.
  *
+ * @deprecated Renamed to {@link OnStart}. Same metadata key, same behaviour - only the name
+ * changed, so no migration is needed beyond the import.
+ *
+ * The rename came with a timing change worth knowing about: the hook used to run inside
+ * `Container.register()`, i.e. mid-scan, while other components were still being constructed.
+ * It now runs from `server.start()` once the whole graph exists. A component resolved from a
+ * server that was created but never started is therefore no longer initialised.
+ *
  * @returns {PropertyDecorator} The property decorator function.
  */
-export const PostConstruct = (): PropertyDecorator => {
-  return (target: object, propertyKey: string): void => {
-    const postConstructs: string[] =
-      getOwnTypedMetadata<string[]>(ComponentConstants.PostConstructKey, target.constructor) || [];
-
-    if (!postConstructs.includes(propertyKey)) {
-      postConstructs.push(propertyKey);
-    }
-
-    defineTypedMetadata<string[]>(ComponentConstants.PostConstructKey, postConstructs, target.constructor);
-  };
-};
+export const PostConstruct = OnStart;

--- a/lib/ioc/component/decorators/index.ts
+++ b/lib/ioc/component/decorators/index.ts
@@ -3,3 +3,5 @@ export * from './Implements';
 export * from '../componentUtils';
 export * from './Strategy';
 export * from './PostConstruct';
+export * from './OnStart';
+export * from './OnStop';

--- a/lib/ioc/constants/ComponentConstants.ts
+++ b/lib/ioc/constants/ComponentConstants.ts
@@ -22,7 +22,11 @@ export class ComponentConstants {
 
   public static readonly ExpressionKey = Symbol('component:expression');
 
+  // Start hooks. The key keeps the old name because @PostConstruct is still a supported alias
+  // for @OnStart and both must land in the same list.
   public static readonly PostConstructKey = Symbol('component:postConstruct');
+
+  public static readonly OnStopKey = Symbol('component:onStop');
 
   public static readonly OverrideKey = Symbol('component:override');
 

--- a/lib/ioc/types/ICoreServiceNamesType.ts
+++ b/lib/ioc/types/ICoreServiceNamesType.ts
@@ -31,6 +31,9 @@ export enum ICoreServiceNames {
   // Schedule Services (Phase 5)
   CRON_RUNNER = 'CronRunner',
 
+  // Lifecycle Services (Phase 5)
+  LIFECYCLE_SERVICE = 'LifecycleService',
+
   // Factory Services (Phase 6+)
   CORE_CONTAINER = 'CoreContainer',
   ASENA_SERVER = 'AsenaServer',

--- a/lib/ioc/types/LifecycleComponent.ts
+++ b/lib/ioc/types/LifecycleComponent.ts
@@ -1,0 +1,31 @@
+import type { Class } from '../../server/types';
+
+/**
+ * Whether the container runs start hooks during construction or hands them to LifecycleService.
+ *
+ * @see Container.setStartHookMode
+ */
+export type StartHookMode = 'immediate' | 'deferred';
+
+/**
+ * A singleton taking part in the server's start/stop lifecycle.
+ *
+ * Recorded in registration order, which the IoC engine topologically sorted, so walking the
+ * list forwards starts dependencies before dependents and walking it backwards stops dependents
+ * before the dependencies they still need.
+ */
+export interface LifecycleComponent {
+  /** The key it was registered under - used to name the component in logs. */
+  key: string;
+  /** The post-processed instance, i.e. the one every dependent was injected with. */
+  instance: any;
+  Class: Class;
+  /**
+   * Its start hooks have completed.
+   *
+   * The gate for stopping: a component that never started has nothing to unwind, and a
+   * `stop()` on a server that failed halfway through boot must not call stop hooks for the
+   * components that never got their turn.
+   */
+  started: boolean;
+}

--- a/lib/ioc/types/index.ts
+++ b/lib/ioc/types/index.ts
@@ -6,6 +6,7 @@ export * from './decorators/ScheduleParams';
 export * from './IocConfig';
 export * from './InjectableComponent';
 export * from './ContainerService';
+export * from './LifecycleComponent';
 export * from './ICoreService';
 export * from './CoreBootstrapPhase';
 export * from './ComponentPostProcessor';

--- a/lib/server/AsenaServer.ts
+++ b/lib/server/AsenaServer.ts
@@ -186,6 +186,22 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
 
     this._logger.info('All components registered and ready to use');
 
+    // Component start hooks, before application setup rather than after it.
+    //
+    // A @Config's hooks are not all closures the framework merely holds on to. `serveOptions()`,
+    // `globalMiddlewares()` and `transport()` are *called* during setup, and prepareMicroservices()
+    // goes on to init() and listen() whatever transport() returned. Every one of those runs
+    // against the components the config injects - so a config that builds a transport from an
+    // injected service, which is the documented pattern in the redis and kafka packages, reaches
+    // for a connection whose @OnStart has not opened it and takes the boot down with it.
+    //
+    // Running the hooks first costs the ability to publish through ulak from an @OnStart, since
+    // the transports are not wired until the next line. That is a real loss and it is the reason
+    // this used to sit further down; it is worth less than a config that cannot use its own
+    // dependencies. `onError()` and `onNotFound()` were always safe either way - the framework
+    // binds those and calls them per request, long after this point.
+    await this.lifecycleService.start();
+
     // Phase 7: Application setup
     this._coreContainer.setPhase(CoreBootstrapPhase.APPLICATION_SETUP);
     await this.prepareConfigs();
@@ -198,12 +214,6 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
       await this.prepareFrontendControllers();
       await this.prepareWebSocket();
     }
-
-    // Component start hooks. Deliberately here and not earlier: the transports are connected
-    // and listening by now, so a hook may publish through ulak - and deliberately not later,
-    // because the socket is still closed, so no request can reach a component whose @OnStart
-    // has not run.
-    await this.lifecycleService.start();
 
     // Phase 8: Server ready
     this._coreContainer.setPhase(CoreBootstrapPhase.SERVER_READY);

--- a/lib/server/AsenaServer.ts
+++ b/lib/server/AsenaServer.ts
@@ -47,6 +47,17 @@ import type { PrepareMicroserviceService } from './src/services/PrepareMicroserv
 import type { CronRunner } from './schedule';
 import type { MessagingInterceptor } from './microservice';
 import type { MicroserviceTransport } from './microservice';
+import type { LifecycleService } from './lifecycle';
+import type { AsenaStopOptions, ShutdownOptions } from './types';
+
+/**
+ * Whatever a catch block or a signal handler received, in a shape safe to put in a log line.
+ *
+ * `String(value)` is not safe here: a rejection can carry any value, and a plain object
+ * stringifies to `[object Object]` - which is exactly the log line nobody can act on.
+ */
+const describeError = (error: unknown): string =>
+  error instanceof Error ? (error.stack ?? error.message) : bun.inspect(error);
 
 /**
  * @description AsenaServer - Main server class for Asena framework
@@ -102,6 +113,9 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
   @Inject(ICoreServiceNames.CRON_RUNNER)
   private cronRunner: CronRunner;
 
+  @Inject(ICoreServiceNames.LIFECYCLE_SERVICE)
+  private lifecycleService: LifecycleService;
+
   // Instance state
   private _port!: number;
 
@@ -118,6 +132,22 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
   private _health?: HealthOptions;
 
   private healthServer?: HealthServer;
+
+  private _shutdown?: ShutdownOptions;
+
+  private _keepAlive?: boolean;
+
+  // The shutdown, once started. Set for the life of the instance rather than for the duration
+  // of the teardown, so it answers both a concurrent stop() and a later one.
+  private stopping?: Promise<void>;
+
+  private signalHandlers = new Map<NodeJS.Signals, () => void>();
+
+  private unhandledErrorHandler?: (error: unknown) => void;
+
+  // Headless processes have no listening socket to hold the event loop open, so a worker whose
+  // @OnStart returned would otherwise exit the moment start() resolved.
+  private keepAliveTimer?: Timer;
 
   // The Bun server returned by the adapter - exposes the actually bound port, which is
   // what a caller needs when starting on port 0 or on a unix socket
@@ -169,6 +199,12 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
       await this.prepareWebSocket();
     }
 
+    // Component start hooks. Deliberately here and not earlier: the transports are connected
+    // and listening by now, so a hook may publish through ulak - and deliberately not later,
+    // because the socket is still closed, so no request can reach a component whose @OnStart
+    // has not run.
+    await this.lifecycleService.start();
+
     // Phase 8: Server ready
     this._coreContainer.setPhase(CoreBootstrapPhase.SERVER_READY);
 
@@ -180,9 +216,12 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
     this.cronRunner.startAll();
 
     if (this._health) {
-      this.healthServer = new HealthServer(this._health, this._ulak, this._logger);
+      this.healthServer = new HealthServer(this._health, this._ulak, this._logger, () => this.lifecycleService.state);
       this.healthServer.start();
     }
+
+    this.installShutdownHandlers();
+    this.installKeepAlive();
 
     if (this._gc) {
       bun.gc(true);
@@ -191,16 +230,94 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
 
   /**
    * @description Stop the server and release resources
-   * @param {boolean} closeActiveConnections - Whether to close active connections immediately
+   *
+   * The order is what makes a shutdown graceful rather than merely quick:
+   * 1. stop taking new work - cron, health, then the HTTP surface
+   * 2. run the components' @OnStop hooks, so they can finish in flight work and publish a last
+   *    message while the transports are still up
+   * 3. only then take the transports down
+   *
+   * Runs once. Concurrent callers await the same teardown, and a later call is a no-op that
+   * returns the original outcome - including its failure, if it had one. Every step was
+   * attempted the first time, so there is nothing a retry could pick up.
+   *
+   * Safe on a server that never started. Note the rule is per component and not "nothing runs":
+   * a component whose start hook already ran gets its stop hook, and post-processors (with the
+   * closure they depend on) run theirs at construction. So a boot that failed before `start()`
+   * still releases what a post-processor acquired - which is the point, since that is where the
+   * telemetry providers live.
+   *
+   * @param {boolean | AsenaStopOptions} options - Legacy boolean is `closeActiveConnections`
    * @returns {Promise<void>}
    */
-  public async stop(closeActiveConnections = true): Promise<void> {
-    this.cronRunner.stopAll();
-    this.healthServer?.stop();
-    // Adapter first: in-flight HTTP handlers may still call ulak.send(), so
+  public async stop(options: boolean | AsenaStopOptions = true): Promise<void> {
+    const {
+      closeActiveConnections = true,
+      drainTimeout,
+      hookTimeout,
+    } = typeof options === 'boolean' ? { closeActiveConnections: options } : options;
+
+    // Latched, not cleared when the teardown settles. Clearing it would make this a guard
+    // against *concurrent* stops only, and a later sequential stop() would walk the whole
+    // sequence again: the component hooks would correctly find nothing to do, but the adapter,
+    // the cron runner and the transports are not self-guarding, so a stopped server would stop
+    // itself a second time and log a second round of teardown errors.
+    this.stopping ??= this.runStop(closeActiveConnections, drainTimeout, hookTimeout);
+
+    return this.stopping;
+  }
+
+  /**
+   * @description The shutdown sequence itself, wrapped by stop()'s idempotence guard.
+   * @param {boolean} closeActiveConnections - Whether to close active connections immediately
+   * @param {number | undefined} drainTimeout - How long transports may drain
+   * @param {number | undefined} hookTimeout - Per-@OnStop ceiling
+   * @returns {Promise<void>}
+   */
+  private async runStop(closeActiveConnections: boolean, drainTimeout?: number, hookTimeout?: number): Promise<void> {
+    this.removeShutdownHandlers();
+    this.clearKeepAlive();
+
+    // First thing, before anything is torn down: the readiness probe has to start answering
+    // 503 while there is still something to drain, or a load balancer keeps sending traffic
+    // right up to the moment the socket closes.
+    this.lifecycleService.markStopping();
+
+    // Every step is contained, for the same reason a failing @OnStop hook does not abort the
+    // rest: the steps are independent, and an adapter that cannot close its socket is no reason
+    // to leave a database pool, a cron timer and a broker subscription behind it. Failures are
+    // collected and raised together at the end, so a caller still learns the shutdown was not
+    // clean - it just learns it after everything that could be released has been.
+    const failures: Error[] = [];
+
+    const release = async (step: string, run: () => unknown): Promise<void> => {
+      try {
+        await run();
+      } catch (error) {
+        this._logger.error(`${yellow('[AsenaServer]')} ${step} failed during shutdown: ${describeError(error)}`);
+        failures.push(error instanceof Error ? error : new Error(`${step}: ${describeError(error)}`));
+      }
+    };
+
+    await release('cron runner', () => this.cronRunner.stopAll());
+    // Adapter before the hooks: in-flight HTTP handlers may still call ulak.send(), so
     // transports must outlive the HTTP surface that uses them
-    await this._adapter?.stop(closeActiveConnections);
-    await this.prepareMicroserviceService.destroy();
+    await release('adapter', () => this._adapter?.stop(closeActiveConnections));
+
+    await release('component stop hooks', () => this.lifecycleService.stop(hookTimeout ?? this._shutdown?.timeout));
+
+    await release('microservice transports', () =>
+      this.prepareMicroserviceService.destroy(drainTimeout === undefined ? undefined : { drainTimeout }),
+    );
+
+    await release('ulak', () => this._ulak.dispose());
+
+    // Last: the probe outlives the drain it is reporting on.
+    await release('health server', () => this.healthServer?.stop());
+
+    if (failures.length > 0) {
+      throw new AggregateError(failures, `Server shutdown completed with ${failures.length} failure(s)`);
+    }
   }
 
   /**
@@ -223,6 +340,198 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
   public health(options: HealthOptions): this {
     this._health = options;
     return this;
+  }
+
+  /**
+   * @description Configure signal handling and shutdown timeouts
+   * Builder pattern for API compatibility
+   * @param {ShutdownOptions} options - Shutdown options
+   * @returns {this}
+   */
+  public shutdown(options: ShutdownOptions): this {
+    this._shutdown = options;
+    return this;
+  }
+
+  /**
+   * @description Hold the event loop open while the server runs
+   * Builder pattern for API compatibility
+   * @param {boolean} enabled - Defaults to true in headless mode, false otherwise
+   * @returns {this}
+   */
+  public keepAlive(enabled: boolean): this {
+    this._keepAlive = enabled;
+    return this;
+  }
+
+  /**
+   * @description Resolve a component from the container by name.
+   *
+   * The same signature the test harness exposes as `app.resolve()`. Reaching through
+   * `server.coreContainer.container.resolve()` worked and was what everybody found instead.
+   *
+   * @param {string} name - Component name
+   * @returns {Promise<T>} The component
+   */
+  public async resolve<T>(name: string): Promise<T> {
+    return (await this._coreContainer.container.resolve<T>(name)) as T;
+  }
+
+  /**
+   * @description Translate process signals into a graceful shutdown.
+   *
+   * Handlers are installed here rather than at construction so a server that is created but
+   * never started leaves the process's signal handling alone, and they are removed again in
+   * stop() so a suite that boots twenty servers does not accumulate twenty listeners - the
+   * leak the otel package's own SIGTERM hook has today.
+   *
+   * @returns {void}
+   */
+  private installShutdownHandlers(): void {
+    for (const signal of this.resolveSignals()) {
+      const handler = (): void => this.onShutdownSignal(signal);
+
+      this.signalHandlers.set(signal, handler);
+      process.on(signal, handler);
+    }
+
+    if (this._shutdown?.onUnhandledError) {
+      this.unhandledErrorHandler = (error: unknown): void => {
+        this._logger.error(`${yellow('[AsenaServer]')} unhandled error, shutting down: ${describeError(error)}`);
+        this.shutdownThenExit(1);
+      };
+
+      process.on('uncaughtException', this.unhandledErrorHandler);
+      process.on('unhandledRejection', this.unhandledErrorHandler);
+    }
+  }
+
+  /**
+   * @description Which signals to listen for.
+   * @returns {NodeJS.Signals[]} Empty when signal handling is switched off
+   */
+  private resolveSignals(): NodeJS.Signals[] {
+    const configured = this._shutdown?.signals ?? true;
+
+    if (configured === false) {
+      return [];
+    }
+
+    return configured === true ? ['SIGTERM', 'SIGINT', 'SIGHUP'] : configured;
+  }
+
+  /**
+   * @description Remove every handler installed by installShutdownHandlers().
+   * @returns {void}
+   */
+  private removeShutdownHandlers(): void {
+    for (const [signal, handler] of this.signalHandlers) {
+      process.off(signal, handler);
+    }
+
+    this.signalHandlers.clear();
+
+    if (this.unhandledErrorHandler) {
+      process.off('uncaughtException', this.unhandledErrorHandler);
+      process.off('unhandledRejection', this.unhandledErrorHandler);
+      this.unhandledErrorHandler = undefined;
+    }
+  }
+
+  /**
+   * @description React to a shutdown signal.
+   *
+   * A second signal while a shutdown is already running is a person pressing Ctrl+C again
+   * because the first one looked stuck; take them at their word and go.
+   *
+   * @param {NodeJS.Signals} signal - The signal received
+   * @returns {void}
+   */
+  private onShutdownSignal(signal: NodeJS.Signals): void {
+    if (this.stopping !== undefined) {
+      this._logger.warn(`${yellow('[AsenaServer]')} ${signal} received again, exiting immediately`);
+      process.exit(130);
+    }
+
+    this._logger.info(`${blue('[AsenaServer]')} ${signal} received, shutting down`);
+    this.shutdownThenExit(0);
+  }
+
+  /**
+   * @description Run the stop sequence, then let the process go.
+   *
+   * Note the `void`: an async function handed straight to `process.on` returns a promise
+   * nobody holds, so a rejection inside it takes the process down with an unhandled rejection -
+   * exactly how a telemetry flush against an unreachable collector turns Ctrl+C into exit 1.
+   *
+   * @param {number} code - Exit code when a force-exit deadline is configured
+   * @returns {void}
+   */
+  private shutdownThenExit(code: number): void {
+    const forceExitAfter = this._shutdown?.forceExitAfter ?? false;
+    let forceTimer: Timer | undefined;
+
+    if (typeof forceExitAfter === 'number') {
+      forceTimer = setTimeout(() => {
+        this._logger.error(`${yellow('[AsenaServer]')} still alive ${forceExitAfter}ms after shutdown, forcing exit`);
+        process.exit(code === 0 ? 1 : code);
+      }, forceExitAfter);
+
+      // Unref'd, and deliberately never cleared: the deadline is about the *process* exiting,
+      // not about stop() resolving. The case worth protecting against is a stop() that finished
+      // cleanly and left something ref'd behind anyway - a pool that never drained, a timer
+      // nobody owns - because that process now hangs until the orchestrator SIGKILLs it.
+      // Clearing this on stop() completing, which is what it used to do, made it fire only when
+      // stop() itself hung: the one thing that can no longer happen, since every hook is
+      // timeout-bounded and every teardown step is contained.
+      //
+      // Unref means a process that does exit on its own is unaffected - the timer cannot be
+      // what keeps it alive, and never delays a clean exit.
+      forceTimer.unref?.();
+    }
+
+    void this.stop()
+      .catch((error: unknown) => {
+        this._logger.error(`${yellow('[AsenaServer]')} shutdown failed: ${describeError(error)}`);
+      })
+      .finally(() => {
+        if (code !== 0) {
+          process.exit(code);
+        }
+      });
+  }
+
+  /**
+   * @description Hold the event loop open for a headless server.
+   *
+   * A headless process has no listening socket, so once start() resolves there may be nothing
+   * ref'd left and bun exits - taking a perfectly healthy worker with it. The alternative was
+   * for the entry file to block on the component's own loop, which is what made the run loop
+   * live in the entry file's stack frame.
+   *
+   * @returns {void}
+   */
+  private installKeepAlive(): void {
+    const enabled = this._keepAlive ?? !this._adapter;
+
+    if (!enabled || this.keepAliveTimer) {
+      return;
+    }
+
+    // A ref'd timer with nothing to do: the only portable way to hold bun's event loop open
+    // without opening a handle we would then have to own.
+    this.keepAliveTimer = setInterval(() => undefined, 2 ** 30);
+  }
+
+  /**
+   * @description Release the keep-alive handle so the process can exit.
+   * @returns {void}
+   */
+  private clearKeepAlive(): void {
+    if (this.keepAliveTimer) {
+      clearInterval(this.keepAliveTimer);
+      this.keepAliveTimer = undefined;
+    }
   }
 
   /**

--- a/lib/server/AsenaServerFactory.ts
+++ b/lib/server/AsenaServerFactory.ts
@@ -3,7 +3,7 @@ import { CoreBootstrapPhase, CoreContainer, ICoreServiceNames } from '../ioc';
 import type { AsenaServer } from './AsenaServer';
 import type { AsenaAdapter } from '../adapter';
 import type { ServerLogger } from '../logger';
-import type { Class } from './types';
+import type { Class, ShutdownOptions } from './types';
 import { readConfigFile } from '../ioc/helper/fileHelper';
 import { ComponentConstants } from '../ioc/constants';
 import { getTypedMetadata } from '../utils/typedMetadata';
@@ -49,6 +49,21 @@ export interface AsenaServerOptions<A extends AsenaAdapter<any, any> = AsenaAdap
   health?: HealthOptions;
 
   /**
+   * Signal handling and shutdown timeouts. Signals are handled by default; pass
+   * `{ signals: false }` to own them yourself.
+   */
+  shutdown?: ShutdownOptions;
+
+  /**
+   * Hold the event loop open while the server runs.
+   *
+   * Defaults to true in headless mode, where there is no listening socket to do it - without
+   * it a worker whose `@OnStart` returned would exit as soon as `start()` resolved. An HTTP
+   * server is held open by its own socket and does not need this.
+   */
+  keepAlive?: boolean;
+
+  /**
    * Replace registered components with pre-created test doubles, keyed by service name
    * (Spring's `@MockBean`).
    *
@@ -72,7 +87,7 @@ export class AsenaServerFactory {
   public static async create<A extends AsenaAdapter<any, any> = AsenaAdapter<any, any>>(
     options: AsenaServerOptions<A>,
   ): Promise<AsenaServer<A>> {
-    const { adapter, logger, port, components, gc, health, overrides } = options;
+    const { adapter, logger, port, components, gc, health, overrides, shutdown, keepAlive } = options;
 
     if (!adapter && !options.headless) {
       throw new Error(
@@ -158,6 +173,10 @@ export class AsenaServerFactory {
     if (port !== undefined) server.port(port);
 
     if (health) server.health(health);
+
+    if (shutdown) server.shutdown(shutdown);
+
+    if (keepAlive !== undefined) server.keepAlive(keepAlive);
 
     if (gc !== undefined) (server as any)._gc = gc;
 

--- a/lib/server/health/HealthServer.ts
+++ b/lib/server/health/HealthServer.ts
@@ -2,18 +2,22 @@ import * as bun from 'bun';
 import { blue, type ServerLogger } from '../../logger';
 import type { HealthOptions } from '../AsenaServerFactory';
 import type { Ulak } from '../messaging/Ulak';
+import { LifecycleState } from '../lifecycle';
 
 /**
  * @description Minimal zero-dependency health endpoint for headless/hybrid deployments.
  *
- * Serves a single endpoint (default GET /healthz) reporting process liveness and
- * per-microservice-transport connection state - built for Kubernetes probes on
- * headless services that have no HTTP adapter.
+ * Three paths, because liveness and readiness answer different questions and a probe that
+ * conflates them restarts a pod that was only busy starting up:
  *
- * Responses:
- * - No microservice transports configured → 200 { status: 'up', uptime }
- * - All transports connected → 200 { status: 'up', uptime, transports: { name: 'connected' } }
- * - Any transport disconnected → 503 { status: 'degraded', ... }
+ * - `GET {path}/live` - is the process alive? Never touches a dependency, so it stays 200 for
+ *   as long as the event loop turns. This is what a restart policy should point at.
+ * - `GET {path}/ready` - should traffic come here? 503 while starting, while stopping, and
+ *   whenever a microservice transport is disconnected.
+ * - `GET {path}` - the original endpoint, same body as `/ready`, kept for compatibility.
+ *
+ * Ready reports 503 the moment shutdown begins, which is the point: a load balancer drops the
+ * instance while it drains rather than after it has already stopped answering.
  */
 export class HealthServer {
   private server?: bun.Server<any>;
@@ -24,6 +28,8 @@ export class HealthServer {
     private readonly options: HealthOptions,
     private readonly ulak: Ulak,
     private readonly logger: ServerLogger,
+    /** Reads the server's runtime state; absent in tests that only exercise transports. */
+    private readonly lifecycleState?: () => LifecycleState,
   ) {}
 
   public start(): void {
@@ -34,17 +40,21 @@ export class HealthServer {
     this.server = bun.serve({
       port: this.options.port,
       fetch: (request: Request) => {
-        const url = new URL(request.url);
+        const { pathname } = new URL(request.url);
 
-        if (url.pathname !== path) {
-          return new Response('Not Found', { status: 404 });
+        if (pathname === `${path}/live`) {
+          return Response.json({ status: 'up', uptime: this.uptime() });
         }
 
-        return this.buildHealthResponse();
+        if (pathname === path || pathname === `${path}/ready`) {
+          return this.buildReadinessResponse();
+        }
+
+        return new Response('Not Found', { status: 404 });
       },
     });
 
-    this.logger.info(`${blue('[Health]')} Health endpoint ready at :${this.options.port}${path}`);
+    this.logger.info(`${blue('[Health]')} Health endpoint ready at :${this.options.port}${path} (+ /live, /ready)`);
   }
 
   public stop(): void {
@@ -52,10 +62,21 @@ export class HealthServer {
     this.server = undefined;
   }
 
-  private buildHealthResponse(): Response {
-    const transports = this.ulak.getMicroserviceTransports();
+  private uptime(): number {
+    return Math.round((Date.now() - this.startedAt) / 1000);
+  }
 
-    const uptime = Math.round((Date.now() - this.startedAt) / 1000);
+  private buildReadinessResponse(): Response {
+    const uptime = this.uptime();
+    const state = this.lifecycleState?.();
+
+    // Draining or not up yet. Reported before the transport check because it is the more
+    // specific answer: a stopping instance is not ready even if every transport is healthy.
+    if (state && state !== LifecycleState.STARTED) {
+      return Response.json({ status: 'not_ready', state, uptime }, { status: 503 });
+    }
+
+    const transports = this.ulak.getMicroserviceTransports();
 
     if (transports.size === 0) {
       return Response.json({ status: 'up', uptime });

--- a/lib/server/index.ts
+++ b/lib/server/index.ts
@@ -1,2 +1,6 @@
 export * from './AsenaServer';
 export * from './AsenaServerFactory';
+// The shapes a caller needs to type a stop() call or a shutdown config, and to read the state
+// the readiness probe reports. Declaring options nobody can import is a half-built API.
+export type { AsenaStopOptions, ShutdownOptions } from './types';
+export { LifecycleState } from './lifecycle';

--- a/lib/server/lifecycle/LifecycleService.ts
+++ b/lib/server/lifecycle/LifecycleService.ts
@@ -1,0 +1,218 @@
+import { ComponentType, CoreService, ICoreServiceNames } from '../../ioc';
+import type { Container, ICoreService, LifecycleComponent } from '../../ioc';
+import { Inject } from '../../ioc/component';
+import { getOwnTypedMetadata } from '../../utils';
+import type { ServerLogger } from '../../logger';
+import { LifecycleState } from './LifecycleState';
+
+/** Per-hook ceiling when none is configured. */
+const DEFAULT_HOOK_TIMEOUT = 5000;
+
+/**
+ * @description LifecycleService - runs component start and stop hooks around the server.
+ *
+ * The container used to run `@PostConstruct` inside `register()`, which put a component's
+ * initialisation in the middle of the scan: the graph was half-built, the microservice
+ * transports did not exist yet, and there was no counterpart to release what the hook had
+ * acquired. Every framework package that opened a connection - database, redis, kafka, otel -
+ * therefore leaked it past `server.stop()`.
+ *
+ * Both halves now live here, and they are symmetric:
+ * - start walks the components in registration order, so dependencies start first
+ * - stop walks them backwards, so a component still has its dependencies while it lets go
+ *
+ * The two failure policies are deliberately different. A start hook that throws aborts the
+ * boot - a half-initialised application should not serve traffic - and the components that
+ * already started are rolled back first. A stop hook that throws or hangs is logged and
+ * skipped, because a shutdown that gives up halfway leaves more behind than one that limps to
+ * the end.
+ *
+ * @internal Driven by AsenaServer.start()/stop(), not used directly by users
+ */
+@CoreService(ICoreServiceNames.LIFECYCLE_SERVICE)
+export class LifecycleService implements ICoreService {
+  public readonly serviceName = 'LifecycleService';
+
+  @Inject(ICoreServiceNames.SERVER_LOGGER)
+  private logger!: ServerLogger;
+
+  @Inject(ICoreServiceNames.CONTAINER)
+  private container!: Container;
+
+  private _state: LifecycleState = LifecycleState.NEW;
+
+  public get state(): LifecycleState {
+    return this._state;
+  }
+
+  /**
+   * @description Run every pending start hook, in registration order.
+   *
+   * Components registered in immediate mode - core services and the post-processor closure -
+   * ran theirs at construction and are skipped here.
+   *
+   * @returns {Promise<void>}
+   * @throws When a hook fails, after rolling back the components that already started
+   */
+  public async start(): Promise<void> {
+    this._state = LifecycleState.STARTING;
+
+    const components = this.container.lifecycle;
+    let started = 0;
+
+    for (const component of components) {
+      if (component.started) continue;
+
+      this.warnIfConfig(component);
+
+      try {
+        await this.container.executeStartHooks(component.instance, component.Class);
+        // Set after the hooks succeed, and regardless of whether the class declared any: it is
+        // what makes the component eligible for its stop hooks, and a component with only an
+        // @OnStop still has something to release.
+        component.started = true;
+        started++;
+      } catch (error) {
+        this._state = LifecycleState.FAILED;
+
+        this.logger.error(
+          `[Lifecycle] ${component.key} failed to start - rolling back ${started} started component(s)`,
+        );
+
+        await this.stopComponents(components, DEFAULT_HOOK_TIMEOUT);
+
+        throw error;
+      }
+    }
+
+    this._state = LifecycleState.STARTED;
+
+    if (started > 0) {
+      this.logger.debug?.(`[Lifecycle] started ${started} component(s)`);
+    }
+  }
+
+  /**
+   * @description Run stop hooks for everything that started, in reverse order.
+   *
+   * Safe to call on a server that never started, or that failed during boot: the components
+   * that never ran their start hooks are skipped, so nothing gets torn down that was never
+   * brought up. Safe to call twice - a stopped component is not stopped again.
+   *
+   * @param {number} hookTimeout - Per-hook ceiling in milliseconds
+   * @returns {Promise<void>}
+   */
+  public async stop(hookTimeout: number = DEFAULT_HOOK_TIMEOUT): Promise<void> {
+    this.markStopping();
+
+    const stopped = await this.stopComponents(this.container.lifecycle, hookTimeout);
+
+    this._state = LifecycleState.STOPPED;
+
+    if (stopped > 0) {
+      this.logger.debug?.(`[Lifecycle] stopped ${stopped} component(s)`);
+    }
+  }
+
+  /**
+   * @description Warn when a @Config component declares a start hook.
+   *
+   * Config classes are read during application setup - `transport()`, `middlewares()`,
+   * `onError()` and friends are all consumed before this point - so a start hook on one runs
+   * after the values it might have been preparing were already taken. The hook still fires;
+   * it just cannot influence the configuration.
+   *
+   * @param {LifecycleComponent} component - The component about to start
+   * @returns {void}
+   */
+  private warnIfConfig(component: LifecycleComponent): void {
+    if (!getOwnTypedMetadata<boolean>(ComponentType.CONFIG, component.Class)) {
+      return;
+    }
+
+    if (this.container.getStartHooks(component.Class).length === 0) {
+      return;
+    }
+
+    this.logger.warn(
+      `[Lifecycle] @Config '${component.key}' declares a start hook, but its config hooks are read during ` +
+        'application setup - before start hooks run. Anything the hook prepares arrives too late to be used.',
+    );
+  }
+
+  /**
+   * @description Flip to STOPPING before any teardown begins.
+   *
+   * Called at the very top of `server.stop()` so the readiness probe answers 503 for the whole
+   * drain, not just for the instant between the hooks finishing and the process exiting. A load
+   * balancer needs the signal while there is still something to drain.
+   *
+   * @returns {void}
+   */
+  public markStopping(): void {
+    this._state = LifecycleState.STOPPING;
+  }
+
+  /**
+   * @description Walk components backwards running their @OnStop hooks, containing every failure.
+   * @param {LifecycleComponent[]} components - The registration-ordered list
+   * @param {number} hookTimeout - Per-hook ceiling in milliseconds
+   * @returns {Promise<number>} How many components were stopped
+   */
+  private async stopComponents(components: LifecycleComponent[], hookTimeout: number): Promise<number> {
+    let stopped = 0;
+
+    for (let index = components.length - 1; index >= 0; index--) {
+      const component = components[index];
+
+      if (!component.started) continue;
+
+      // Cleared before the hooks run, not after: a hook that throws has already done whatever
+      // part of its teardown it managed, and running it a second time on the next stop() would
+      // be worse than skipping it.
+      component.started = false;
+      stopped++;
+
+      for (const hook of this.container.getStopHooks(component.Class)) {
+        const label = `${component.Class.name}.${hook}()`;
+
+        try {
+          await this.withTimeout(component.instance[hook](), hookTimeout, label);
+        } catch (error) {
+          this.logger.error(
+            `[Lifecycle] @OnStop hook '${label}' failed, continuing shutdown: ${(error as Error).message}`,
+          );
+        }
+      }
+    }
+
+    return stopped;
+  }
+
+  /**
+   * @description Bound wait on a hook.
+   *
+   * A hook that never settles would otherwise hold the process open forever - the exact failure
+   * a graceful shutdown is supposed to prevent. The timer is always cleared, including on the
+   * happy path, so a fast shutdown is not held up by a pending timeout.
+   *
+   * @param {unknown} result - Whatever the hook returned
+   * @param {number} ms - Ceiling in milliseconds
+   * @param {string} label - Hook name for the error message
+   * @returns {Promise<void>}
+   */
+  private async withTimeout(result: unknown, ms: number, label: string): Promise<void> {
+    let timer: Timer | undefined;
+
+    try {
+      await Promise.race([
+        Promise.resolve(result),
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => reject(new Error(`${label} did not finish within ${ms}ms`)), ms);
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}

--- a/lib/server/lifecycle/LifecycleService.ts
+++ b/lib/server/lifecycle/LifecycleService.ts
@@ -1,7 +1,6 @@
-import { ComponentType, CoreService, ICoreServiceNames } from '../../ioc';
+import { CoreService, ICoreServiceNames } from '../../ioc';
 import type { Container, ICoreService, LifecycleComponent } from '../../ioc';
 import { Inject } from '../../ioc/component';
-import { getOwnTypedMetadata } from '../../utils';
 import type { ServerLogger } from '../../logger';
 import { LifecycleState } from './LifecycleState';
 
@@ -63,8 +62,6 @@ export class LifecycleService implements ICoreService {
     for (const component of components) {
       if (component.started) continue;
 
-      this.warnIfConfig(component);
-
       try {
         await this.container.executeStartHooks(component.instance, component.Class);
         // Set after the hooks succeed, and regardless of whether the class declared any: it is
@@ -112,32 +109,6 @@ export class LifecycleService implements ICoreService {
     if (stopped > 0) {
       this.logger.debug?.(`[Lifecycle] stopped ${stopped} component(s)`);
     }
-  }
-
-  /**
-   * @description Warn when a @Config component declares a start hook.
-   *
-   * Config classes are read during application setup - `transport()`, `middlewares()`,
-   * `onError()` and friends are all consumed before this point - so a start hook on one runs
-   * after the values it might have been preparing were already taken. The hook still fires;
-   * it just cannot influence the configuration.
-   *
-   * @param {LifecycleComponent} component - The component about to start
-   * @returns {void}
-   */
-  private warnIfConfig(component: LifecycleComponent): void {
-    if (!getOwnTypedMetadata<boolean>(ComponentType.CONFIG, component.Class)) {
-      return;
-    }
-
-    if (this.container.getStartHooks(component.Class).length === 0) {
-      return;
-    }
-
-    this.logger.warn(
-      `[Lifecycle] @Config '${component.key}' declares a start hook, but its config hooks are read during ` +
-        'application setup - before start hooks run. Anything the hook prepares arrives too late to be used.',
-    );
   }
 
   /**

--- a/lib/server/lifecycle/LifecycleState.ts
+++ b/lib/server/lifecycle/LifecycleState.ts
@@ -1,0 +1,21 @@
+/**
+ * @description Where the server is in its start/stop cycle.
+ *
+ * Deliberately separate from `CoreBootstrapPhase`, which describes how the container was wired
+ * and only ever moves forwards. This is runtime state: it goes back and forth, a readiness
+ * probe reads it, and `stop()` uses it to decide what may be torn down.
+ */
+export enum LifecycleState {
+  /** Constructed, `start()` not called yet. */
+  NEW = 'NEW',
+  /** Inside `start()` - start hooks are running. */
+  STARTING = 'STARTING',
+  /** Every start hook completed; the server is serving. */
+  STARTED = 'STARTED',
+  /** Inside `stop()` - already draining, so no longer ready for traffic. */
+  STOPPING = 'STOPPING',
+  /** Stopped. Stop hooks have run for everything that started. */
+  STOPPED = 'STOPPED',
+  /** A start hook threw. Whatever had started was rolled back. */
+  FAILED = 'FAILED',
+}

--- a/lib/server/lifecycle/index.ts
+++ b/lib/server/lifecycle/index.ts
@@ -1,0 +1,2 @@
+export * from './LifecycleService';
+export * from './LifecycleState';

--- a/lib/server/types/ShutdownOptions.ts
+++ b/lib/server/types/ShutdownOptions.ts
@@ -1,0 +1,83 @@
+/**
+ * @description How the server should react to the process being asked to go away.
+ *
+ * Signal handling is on by default. Every deployment that rolls a pod needs the same four
+ * lines, getting them slightly wrong is invisible until the next deploy, and a framework that
+ * already owns `start()` and `stop()` is the right place for it. Listeners are installed in
+ * `start()` and removed in `stop()`, so a process that boots several servers - a test suite -
+ * does not accumulate them.
+ */
+export interface ShutdownOptions {
+  /**
+   * Install process signal handlers that call `stop()`.
+   *
+   * `true` (default) covers SIGTERM, SIGINT and SIGHUP. Pass an explicit list to narrow it, or
+   * `false` to own the signals yourself.
+   *
+   * @default true
+   */
+  signals?: boolean | NodeJS.Signals[];
+
+  /**
+   * Per-hook ceiling for `@OnStop`, in milliseconds.
+   *
+   * @default 5000
+   */
+  timeout?: number;
+
+  /**
+   * Force the process to exit if it is still alive this many milliseconds after a
+   * signal-triggered shutdown began.
+   *
+   * The escape hatch for a handle nothing owns up to - an undisposed timer, a socket that will
+   * not close. Note the deadline is on the *process*, not on `stop()`: the case that actually
+   * strands a pod is a shutdown that completed cleanly and left something ref'd behind anyway.
+   * The timer is unref'd, so a process that exits on its own never waits for it.
+   *
+   * `false` leaves the process to exit on its own once the event loop empties, which is the
+   * honest default: a process that will not exit is a bug worth seeing rather than papering
+   * over. Exits non-zero, because a forced exit is not a clean one.
+   *
+   * @default false
+   */
+  forceExitAfter?: number | false;
+
+  /**
+   * Treat an uncaught exception or unhandled rejection as a shutdown request: log it, run the
+   * stop sequence, then exit non-zero.
+   *
+   * Off by default. It turns a crash into a graceful teardown, which is usually what a
+   * production process wants - but it also swallows the stack Bun would otherwise print at the
+   * top level, so it is opt-in.
+   *
+   * @default false
+   */
+  onUnhandledError?: boolean;
+}
+
+/**
+ * @description Options for `AsenaServer.stop()`.
+ *
+ * `stop()` used to take a bare boolean, which left nowhere to put the drain timeout the
+ * microservice transports already supported - so an application could not reach it at all.
+ * The boolean is still accepted.
+ */
+export interface AsenaStopOptions {
+  /**
+   * Close in-flight connections instead of waiting for them.
+   *
+   * @default true
+   */
+  closeActiveConnections?: boolean;
+
+  /**
+   * How long microservice transports may drain in-flight messages, in milliseconds.
+   * Passed through to each transport's `destroy()`.
+   */
+  drainTimeout?: number;
+
+  /**
+   * Per-hook ceiling for `@OnStop`, in milliseconds. Overrides `shutdown.timeout`.
+   */
+  hookTimeout?: number;
+}

--- a/lib/server/types/index.ts
+++ b/lib/server/types/index.ts
@@ -1,2 +1,3 @@
 export * from './Class';
+export * from './ShutdownOptions';
 export * from '../web/middleware/AsenaStaticServeService';

--- a/lib/test/harness/createTestApp.ts
+++ b/lib/test/harness/createTestApp.ts
@@ -61,6 +61,12 @@ export async function createTestApp<A extends AsenaAdapter<any, any> = AsenaAdap
     overrides,
     // Port 0 lets Bun assign a free ephemeral port, which removes the random-port race
     port: options.port ?? 0,
+    // A test process boots many servers and owns its own signal handling; installing a handler
+    // per app would leave a listener behind for every one of them. Also keeps a stray Ctrl+C
+    // from being intercepted by whichever test app happened to be running.
+    shutdown: { signals: false },
+    // Nothing here should hold the event loop open once the suite is done.
+    keepAlive: false,
   });
 
   await server.start(socketPath ? { unix: socketPath } : undefined);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asenajs/asena",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "author": "LibirSoft",
   "repository": {
     "type": "git",
@@ -134,13 +134,17 @@
     "build": "bun run clean && tsc",
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "clean": "rm -rf dist",
+    "prepublishOnly": "bun run build",
     "pre-release": "bun run check && bun test && bun run build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "check": "bun run lint && bun run format:check",
-    "check:fix": "bun run lint:fix && bun run format"
+    "check:fix": "bun run lint:fix && bun run format",
+    "changeset": "changeset",
+    "version": "changeset version",
+    "release": "bun run build && changeset publish"
   },
   "types": "dist/index.d.ts"
 }

--- a/test/adapter/HttpException.test.ts
+++ b/test/adapter/HttpException.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it } from 'bun:test';
+import { HttpException } from '../../lib/adapter';
+import { ClientErrorStatusCode, ServerErrorStatusCode } from '../../lib/server/web/types';
+
+describe('HttpException', () => {
+  describe('constructor', () => {
+    it('should create HttpException with string body', () => {
+      const exception = new HttpException(404, 'Not Found');
+
+      expect(exception.status).toBe(404);
+      expect(exception.body).toBe('Not Found');
+      expect(exception.message).toBe('Not Found');
+      expect(exception.name).toBe('HttpException');
+    });
+
+    it('should create HttpException with object body', () => {
+      const body = { error: 'Invalid input', field: 'email' };
+      const exception = new HttpException(400, body);
+
+      expect(exception.status).toBe(400);
+      expect(exception.body).toEqual(body);
+      expect(exception.message).toBe(JSON.stringify(body));
+      expect(exception.name).toBe('HttpException');
+    });
+
+    it('should create HttpException with custom headers', () => {
+      const exception = new HttpException(429, 'Too Many Requests', {
+        headers: { 'Retry-After': '60' },
+      });
+
+      expect(exception.status).toBe(429);
+      expect(exception.body).toBe('Too Many Requests');
+      expect(exception.options?.headers).toEqual({ 'Retry-After': '60' });
+    });
+
+    it('should create HttpException with empty body by default', () => {
+      const exception = new HttpException(500);
+
+      expect(exception.status).toBe(500);
+      expect(exception.body).toBe('');
+      expect(exception.message).toBe('');
+    });
+
+    it('should create HttpException with custom statusText', () => {
+      const exception = new HttpException(200, 'Success', {
+        statusText: 'Custom Status',
+      });
+
+      expect(exception.status).toBe(200);
+      expect(exception.options?.statusText).toBe('Custom Status');
+    });
+  });
+
+  describe('getResponse', () => {
+    it('should convert string body to Response', () => {
+      const exception = new HttpException(404, 'Not Found');
+      const response = exception.getResponse();
+
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(404);
+      expect(response.body).toBeDefined();
+    });
+
+    it('should convert object body to JSON Response', async () => {
+      const body = { error: 'Validation failed', fields: ['email', 'password'] };
+      const exception = new HttpException(400, body);
+      const response = exception.getResponse();
+
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(400);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(body);
+    });
+
+    it('should include custom headers in Response', () => {
+      const exception = new HttpException(401, 'Unauthorized', {
+        headers: { 'WWW-Authenticate': 'Bearer' },
+      });
+      const response = exception.getResponse();
+
+      expect(response.headers.get('WWW-Authenticate')).toBe('Bearer');
+    });
+
+    it('should set Content-Type to application/json for object bodies', () => {
+      const exception = new HttpException(400, { error: 'Bad Request' });
+      const response = exception.getResponse();
+
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+    });
+
+    it('should not override existing Content-Type header', () => {
+      const exception = new HttpException(
+        200,
+        { data: 'test' },
+        {
+          headers: { 'Content-Type': 'application/vnd.api+json' },
+        },
+      );
+      const response = exception.getResponse();
+
+      expect(response.headers.get('Content-Type')).toBe('application/vnd.api+json');
+    });
+
+    it('should include custom statusText in Response', () => {
+      const exception = new HttpException(200, 'OK', {
+        statusText: 'Custom OK',
+      });
+      const response = exception.getResponse();
+
+      expect(response.statusText).toBe('Custom OK');
+    });
+
+    it('should handle empty body', async () => {
+      const exception = new HttpException(204);
+      const response = exception.getResponse();
+
+      expect(response.status).toBe(204);
+
+      const text = await response.text();
+
+      expect(text).toBe('');
+    });
+
+    it('should handle complex nested objects', async () => {
+      const body = {
+        error: 'Validation Error',
+        details: {
+          fields: [
+            { name: 'email', errors: ['required', 'invalid format'] },
+            { name: 'age', errors: ['must be positive'] },
+          ],
+        },
+      };
+      const exception = new HttpException(422, body);
+      const response = exception.getResponse();
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(body);
+    });
+
+    it('should handle multiple custom headers', () => {
+      const exception = new HttpException(503, 'Service Unavailable', {
+        headers: {
+          'Retry-After': '120',
+          'X-Rate-Limit': '100',
+          'X-Custom-Header': 'value',
+        },
+      });
+      const response = exception.getResponse();
+
+      expect(response.headers.get('Retry-After')).toBe('120');
+      expect(response.headers.get('X-Rate-Limit')).toBe('100');
+      expect(response.headers.get('X-Custom-Header')).toBe('value');
+    });
+  });
+
+  describe('Common HTTP status codes', () => {
+    it('should handle 400 Bad Request', () => {
+      const exception = new HttpException(400, 'Bad Request');
+
+      expect(exception.status).toBe(400);
+
+      const response = exception.getResponse();
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should handle 401 Unauthorized', () => {
+      const exception = new HttpException(401, 'Unauthorized');
+
+      expect(exception.status).toBe(401);
+
+      const response = exception.getResponse();
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should handle 403 Forbidden', () => {
+      const exception = new HttpException(403, 'Forbidden');
+
+      expect(exception.status).toBe(403);
+
+      const response = exception.getResponse();
+
+      expect(response.status).toBe(403);
+    });
+
+    it('should handle 404 Not Found', () => {
+      const exception = new HttpException(404, 'Not Found');
+
+      expect(exception.status).toBe(404);
+
+      const response = exception.getResponse();
+
+      expect(response.status).toBe(404);
+    });
+
+    it('should handle 429 Too Many Requests', () => {
+      const exception = new HttpException(429, 'Too Many Requests');
+
+      expect(exception.status).toBe(429);
+
+      const response = exception.getResponse();
+
+      expect(response.status).toBe(429);
+    });
+
+    it('should handle 500 Internal Server Error', () => {
+      const exception = new HttpException(500, 'Internal Server Error');
+
+      expect(exception.status).toBe(500);
+
+      const response = exception.getResponse();
+
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle very long string bodies', async () => {
+      const longString = 'a'.repeat(10000);
+      const exception = new HttpException(413, longString);
+      const response = exception.getResponse();
+
+      const text = await response.text();
+
+      expect(text.length).toBe(10000);
+    });
+
+    it('should handle special characters in body', async () => {
+      const body = 'Special chars: <>&"\'\n\t';
+      const exception = new HttpException(400, body);
+      const response = exception.getResponse();
+
+      const text = await response.text();
+
+      expect(text).toBe(body);
+    });
+
+    it('should handle unicode characters', async () => {
+      const body = { message: '你好世界 🌍 مرحبا بالعالم' };
+      const exception = new HttpException(200, body);
+      const response = exception.getResponse();
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(body);
+    });
+
+    it('should handle null values in object body', async () => {
+      const body = { value: null, empty: null };
+      const exception = new HttpException(200, body);
+      const response = exception.getResponse();
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(body);
+    });
+
+    it('should handle arrays in body', async () => {
+      const body = { items: [1, 2, 3, 4, 5] };
+      const exception = new HttpException(200, body);
+      const response = exception.getResponse();
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual(body);
+    });
+  });
+
+  describe('HttpStatusCode support', () => {
+    it('should accept ClientErrorStatusCode enum', () => {
+      const exception = new HttpException(ClientErrorStatusCode.NotFound, 'Not Found');
+
+      expect(exception.status).toBe(404);
+      expect(exception.body).toBe('Not Found');
+    });
+
+    it('should accept ServerErrorStatusCode enum', () => {
+      const exception = new HttpException(ServerErrorStatusCode.InternalServerError, 'Server Error');
+
+      expect(exception.status).toBe(500);
+
+      const response = exception.getResponse();
+
+      expect(response.status).toBe(500);
+    });
+
+    it('should still accept plain numbers', () => {
+      const exception = new HttpException(418, "I'm a teapot");
+
+      expect(exception.status).toBe(418);
+    });
+  });
+
+  describe('cause support', () => {
+    it('should support cause option', () => {
+      const cause = new Error('original database error');
+      const exception = new HttpException(500, 'Internal Server Error', { cause });
+
+      expect(exception.cause).toBe(cause);
+      expect(exception.status).toBe(500);
+    });
+
+    it('should support cause with headers', () => {
+      const cause = new Error('db connection failed');
+      const exception = new HttpException(500, 'Database Error', {
+        cause,
+        headers: { 'X-Error-Source': 'database' },
+      });
+
+      expect(exception.cause).toBe(cause);
+
+      const response = exception.getResponse();
+
+      expect(response.headers.get('X-Error-Source')).toBe('database');
+      expect(response.status).toBe(500);
+    });
+
+    it('should work without cause (backward compatible)', () => {
+      const exception = new HttpException(400, 'Bad Request', {
+        headers: { 'X-Custom': 'value' },
+      });
+
+      expect(exception.cause).toBeUndefined();
+      expect(exception.options?.headers).toEqual({ 'X-Custom': 'value' });
+    });
+
+    it('should support cause with HttpStatusCode enum', () => {
+      const cause = new TypeError('invalid type');
+      const exception = new HttpException(ClientErrorStatusCode.BadRequest, 'Validation Error', { cause });
+
+      expect(exception.status).toBe(400);
+      expect(exception.cause).toBe(cause);
+    });
+  });
+});

--- a/test/adapter/HttpExceptionBrand.test.ts
+++ b/test/adapter/HttpExceptionBrand.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import { HTTP_EXCEPTION, HttpException, isHttpException, type HttpExceptionLike } from '../../lib/adapter';
+
+/**
+ * `isHttpException` is the predicate both adapters use to decide whether a thrown error is a
+ * deliberate HTTP status or an unhandled failure - it picks the response *and* the log level on
+ * each of them. It lived here untested: the adapters each had their own brand suite, and this
+ * package, which owns the symbol and the predicate, had none.
+ *
+ * The contract is deliberately narrow. Only the brand and `status` are guaranteed; `getResponse`
+ * is optional, because the hono adapter brands `HTTPException` - a class it does not own - and a
+ * foreign exception type may carry neither a body nor a way to build a response. Anything reading
+ * more than `status` off a match has to check first.
+ */
+describe('HTTP exception brand', () => {
+  test('the class this package exports is branded', () => {
+    expect(isHttpException(new HttpException(401, 'Unauthorized'))).toBe(true);
+  });
+
+  test('a subclass inherits the brand', () => {
+    class Forbidden extends HttpException {
+      public constructor() {
+        super(403, 'Forbidden');
+      }
+    }
+
+    expect(isHttpException(new Forbidden())).toBe(true);
+  });
+
+  test('status is readable through the narrowed type', () => {
+    const error: unknown = new HttpException(429, 'Too Many Requests');
+
+    expect(isHttpException(error) && error.status).toBe(429);
+  });
+
+  // The case the brand exists for. Two resolved copies of this package produce two distinct
+  // `HttpException` classes and `instanceof` answers false for one of them - silently, because
+  // the API keeps responding and only the status is wrong. `Symbol.for` crosses copies.
+  test('recognises an exception from a second copy of this package', () => {
+    const foreign: unknown = Object.assign(Object.create(Error.prototype), {
+      [HTTP_EXCEPTION]: true,
+      status: 401,
+      message: 'Unauthorized',
+    });
+
+    expect(foreign instanceof HttpException).toBe(false);
+    expect(isHttpException(foreign)).toBe(true);
+    expect(isHttpException(foreign) && foreign.status).toBe(401);
+  });
+
+  test('a branded exception need not carry getResponse()', () => {
+    const brandedOnly: unknown = Object.assign(Object.create(Error.prototype), {
+      [HTTP_EXCEPTION]: true,
+      status: 503,
+    });
+
+    expect(isHttpException(brandedOnly)).toBe(true);
+
+    // What an adapter has to write, and the reason `getResponse` is optional on the interface.
+    const narrowed = brandedOnly as HttpExceptionLike;
+
+    expect(typeof narrowed.getResponse).toBe('undefined');
+    expect(typeof new HttpException(503, 'x').getResponse).toBe('function');
+  });
+
+  test('a plain Error, null and a false brand are not matched', () => {
+    expect(isHttpException(new Error('nope'))).toBe(false);
+    expect(isHttpException(null)).toBe(false);
+    expect(isHttpException(undefined)).toBe(false);
+    expect(isHttpException({ [HTTP_EXCEPTION]: false })).toBe(false);
+  });
+
+  test('the brand is the registered symbol, so it survives module duplication', () => {
+    // Compared as a plain symbol: HTTP_EXCEPTION is typed `unique symbol`, and toBe() narrows
+    // its parameter to that same type, so passing the Symbol.for() result - which is only known
+    // to be `symbol` - does not typecheck. The runtime identity is exactly what is under test.
+    expect(HTTP_EXCEPTION as symbol).toBe(Symbol.for('asena.httpException'));
+  });
+});

--- a/test/integration/FactoryOverrides.test.ts
+++ b/test/integration/FactoryOverrides.test.ts
@@ -77,9 +77,18 @@ describe('AsenaServerFactory overrides', () => {
   });
 
   test('should construct the real class when it is not overridden', async () => {
-    await createServer();
+    const server = await createServer();
+
+    // create() builds the graph; the start hook belongs to start(). Splitting the assertion is
+    // the point of the change - a component is constructed during the scan but not initialised
+    // until the server actually starts.
+    expect(lifecycle).toEqual(['MailService.constructor']);
+
+    await server.start();
 
     expect(lifecycle).toEqual(['MailService.constructor', 'MailService.connect']);
+
+    await server.stop();
   });
 
   test('should leave non-overridden components untouched', async () => {

--- a/test/integration/GracefulShutdown.test.ts
+++ b/test/integration/GracefulShutdown.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+
+const fixture = (name: string) => join(import.meta.dir, 'fixtures', `${name}.ts`);
+
+/**
+ * The end-to-end proof for the lifecycle: a real process, a real signal.
+ *
+ * Everything else in this suite drives start()/stop() in-process, which cannot show the two
+ * things that actually bit a downstream application - that a headless process stays alive once
+ * `start()` returns, and that an external SIGTERM reaches the components' stop hooks instead of
+ * killing the process mid-step.
+ *
+ * The unhappy paths are here for a reason. The first version of this lifecycle awaited each
+ * teardown step unguarded, so one failing step stranded every step behind it - a database pool
+ * and a broker subscription left open because an unrelated socket refused to close. No test
+ * caught it; it was found by reading the code. The rule that fell out: every boundary where a
+ * failure is *contained* needs a test that makes it fail, not just one that makes it work.
+ */
+const spawnWorker = (name = 'graceful-worker') =>
+  Bun.spawn(['bun', fixture(name)], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+/**
+ * Accumulate a stream in the background.
+ *
+ * One consumer, not two: a ReadableStream can only be read once, so waiting for a marker and
+ * then reading the rest has to come off the same buffer.
+ */
+const tail = (stream: ReadableStream<Uint8Array>) => {
+  const decoder = new TextDecoder();
+  let output = '';
+
+  const drained = (async () => {
+    // Reader loop rather than `for await`: bun's ReadableStream is async-iterable at runtime,
+    // but the DOM lib TypeScript resolves here does not declare Symbol.asyncIterator on it.
+    const reader = stream.getReader();
+
+    for (;;) {
+      const { done, value } = await reader.read();
+
+      if (value) output += decoder.decode(value, { stream: true });
+      if (done) return;
+    }
+  })();
+
+  return {
+    text: () => output,
+    drained,
+    waitFor: async (marker: string, timeoutMs = 10_000): Promise<void> => {
+      const deadline = Date.now() + timeoutMs;
+
+      while (Date.now() < deadline) {
+        if (output.includes(marker)) return;
+
+        await Bun.sleep(10);
+      }
+
+      throw new Error(`never saw '${marker}'. Got:\n${output}`);
+    },
+  };
+};
+
+describe('graceful shutdown', () => {
+  test('a headless worker stays alive after start() returns', async () => {
+    const worker = spawnWorker();
+    const stdout = tail(worker.stdout);
+
+    try {
+      await stdout.waitFor('SERVER_STARTED');
+
+      expect(stdout.text()).toContain('WORKER_STARTED');
+
+      // The hook returned and start() resolved - yet the process is still here, because the
+      // server holds the event loop open. Without that a headless worker would exit right now.
+      await Bun.sleep(200);
+      expect(worker.killed).toBe(false);
+      expect(worker.exitCode).toBeNull();
+    } finally {
+      worker.kill('SIGKILL');
+      await worker.exited;
+    }
+  }, 20_000);
+
+  test('SIGTERM runs the stop hooks and exits cleanly', async () => {
+    const worker = spawnWorker();
+    const stdout = tail(worker.stdout);
+
+    await stdout.waitFor('SERVER_STARTED');
+
+    // Long enough to be mid-loop rather than in the first tick.
+    await Bun.sleep(120);
+
+    worker.kill('SIGTERM');
+
+    const exitCode = await worker.exited;
+
+    await stdout.drained;
+
+    expect(stdout.text()).toContain('WORKER_STOPPED');
+    // Cooperative, not killed: the loop ran several ticks and the hook observed them.
+    expect(stdout.text()).toMatch(/WORKER_STOPPED ticks=[1-9]\d*/);
+    expect(exitCode).toBe(0);
+  }, 20_000);
+
+  test('SIGINT does the same', async () => {
+    const worker = spawnWorker();
+    const stdout = tail(worker.stdout);
+
+    await stdout.waitFor('SERVER_STARTED');
+
+    worker.kill('SIGINT');
+
+    const exitCode = await worker.exited;
+
+    await stdout.drained;
+
+    expect(stdout.text()).toContain('WORKER_STOPPED');
+    expect(exitCode).toBe(0);
+  }, 20_000);
+
+  test('a throwing stop hook does not strand the components behind it', async () => {
+    const worker = spawnWorker('failing-stop-worker');
+    const stdout = tail(worker.stdout);
+
+    await stdout.waitFor('SERVER_STARTED');
+
+    worker.kill('SIGTERM');
+
+    const exitCode = await worker.exited;
+
+    await stdout.drained;
+
+    // BrokenTeardown throws; RegisteredEarlier stops after it because stop order is the reverse
+    // of start order. Seeing its line is the proof that one component failing to let go does not
+    // end the shutdown - and the process still exits cleanly.
+    expect(stdout.text()).toContain('EARLIER_STOPPED');
+    expect(exitCode).toBe(0);
+  }, 20_000);
+
+  test('forceExitAfter ends a process a stop hook will not let go of', async () => {
+    const worker = spawnWorker('hanging-stop-worker');
+    const stdout = tail(worker.stdout);
+
+    await stdout.waitFor('SERVER_STARTED');
+
+    const startedAt = Date.now();
+
+    worker.kill('SIGTERM');
+
+    const exitCode = await worker.exited;
+    const elapsed = Date.now() - startedAt;
+
+    await stdout.drained;
+
+    expect(stdout.text()).toContain('STUCK_STOPPING');
+    // Non-zero: this was not a clean exit and the exit code should not pretend otherwise.
+    expect(exitCode).not.toBe(0);
+    // The 1000ms deadline, not the 5000ms default hook timeout and not never.
+    expect(elapsed).toBeLessThan(5_000);
+  }, 20_000);
+});

--- a/test/integration/fixtures/failing-stop-worker.ts
+++ b/test/integration/fixtures/failing-stop-worker.ts
@@ -1,0 +1,51 @@
+/**
+ * A headless worker whose stop hook throws, run as a real process by GracefulShutdown.test.ts.
+ *
+ * The question it answers: does a component that fails to let go take the process down with it,
+ * or does the shutdown carry on and exit cleanly? A deploy that rolls a pod must not depend on
+ * every component's teardown being flawless.
+ *
+ * Not a *.test.ts file, so the test runner does not pick it up on its own.
+ */
+import { AsenaServerFactory } from '../../../lib/server';
+import { Service } from '../../../lib/server/decorators';
+import { OnStart, OnStop } from '../../../lib/ioc/component';
+import { silentLogger } from '../../../lib/test/harness/silentLogger';
+
+@Service()
+class BrokenTeardown {
+  @OnStart()
+  public start(): void {
+    console.log('BROKEN_STARTED');
+  }
+
+  @OnStop()
+  public stop(): void {
+    throw new Error('teardown blew up');
+  }
+}
+
+@Service()
+class RegisteredEarlier {
+  @OnStart()
+  public start(): void {
+    console.log('EARLIER_STARTED');
+  }
+
+  // Registered before BrokenTeardown, so it stops *after* it. If a throwing hook aborted the
+  // sequence this line would never be printed.
+  @OnStop()
+  public stop(): void {
+    console.log('EARLIER_STOPPED');
+  }
+}
+
+const server = await AsenaServerFactory.create({
+  headless: true,
+  logger: silentLogger,
+  components: [RegisteredEarlier, BrokenTeardown],
+});
+
+await server.start();
+
+console.log('SERVER_STARTED');

--- a/test/integration/fixtures/graceful-worker.ts
+++ b/test/integration/fixtures/graceful-worker.ts
@@ -1,0 +1,75 @@
+/**
+ * A headless worker, run as a real process by GracefulShutdown.test.ts.
+ *
+ * This is the shape the framework could not support before: a component that runs for the
+ * process's lifetime, started and stopped by the container. Note what the entry file does NOT
+ * do - it does not resolve the component out of the container, it does not translate signals,
+ * and it does not block on the run loop. Two lines, same as an HTTP application's.
+ *
+ * Not a *.test.ts file, so the test runner does not pick it up on its own.
+ */
+import { AsenaServerFactory } from '../../../lib/server';
+import { Service } from '../../../lib/server/decorators';
+import { OnStart, OnStop } from '../../../lib/ioc/component';
+import { silentLogger } from '../../../lib/test/harness/silentLogger';
+
+@Service()
+class RunWorker {
+  private running = false;
+
+  private ticks = 0;
+
+  /** Resolves the current sleep early, so stop() does not have to wait out a poll interval. */
+  private wake?: () => void;
+
+  /** The loop itself, so stop() can wait for the tick in flight to finish. */
+  private loop?: Promise<void>;
+
+  @OnStart()
+  public start(): void {
+    this.running = true;
+    this.loop = this.run();
+
+    // The hook returns here. The loop keeps going on its own, and start() completes.
+    console.log('WORKER_STARTED');
+  }
+
+  @OnStop()
+  public async stop(): Promise<void> {
+    this.running = false;
+    this.wake?.();
+
+    // Cooperative: let the tick in flight finish rather than being killed mid-step.
+    await this.loop;
+
+    console.log(`WORKER_STOPPED ticks=${this.ticks}`);
+  }
+
+  private async run(): Promise<void> {
+    while (this.running) {
+      this.ticks++;
+      await this.sleep(25);
+    }
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, ms);
+
+      this.wake = () => {
+        clearTimeout(timer);
+        resolve();
+      };
+    });
+  }
+}
+
+const server = await AsenaServerFactory.create({
+  headless: true,
+  logger: silentLogger,
+  components: [RunWorker],
+});
+
+await server.start();
+
+console.log('SERVER_STARTED');

--- a/test/integration/fixtures/hanging-stop-worker.ts
+++ b/test/integration/fixtures/hanging-stop-worker.ts
@@ -1,0 +1,51 @@
+/**
+ * A headless worker whose stop hook never settles *and* holds the event loop open, run as a
+ * real process by GracefulShutdown.test.ts.
+ *
+ * This is the case `shutdown.forceExitAfter` exists for. The per-hook timeout gets the shutdown
+ * moving again, but it cannot make a resource let go of the loop - so without a force deadline
+ * the process sits there after a SIGTERM, and the orchestrator eventually SIGKILLs it, which is
+ * the ungraceful ending the whole lifecycle is meant to avoid.
+ *
+ * Not a *.test.ts file, so the test runner does not pick it up on its own.
+ */
+import { AsenaServerFactory } from '../../../lib/server';
+import { Service } from '../../../lib/server/decorators';
+import { OnStart, OnStop } from '../../../lib/ioc/component';
+import { silentLogger } from '../../../lib/test/harness/silentLogger';
+
+@Service()
+class Stuck {
+  private anchor?: Timer;
+
+  @OnStart()
+  public start(): void {
+    console.log('STUCK_STARTED');
+  }
+
+  @OnStop()
+  public stop(): Promise<void> {
+    console.log('STUCK_STOPPING');
+
+    // A ref'd timer nobody clears: the stand-in for a connection pool that will not drain.
+    this.anchor = setInterval(() => undefined, 1000);
+
+    return new Promise<void>(() => {});
+  }
+}
+
+const server = await AsenaServerFactory.create({
+  headless: true,
+  logger: silentLogger,
+  components: [Stuck],
+  shutdown: {
+    // Well under the 5000ms per-hook default, so the force deadline is what ends this process
+    // and the test does not have to wait out the hook timeout to prove it.
+    timeout: 200,
+    forceExitAfter: 1000,
+  },
+});
+
+await server.start();
+
+console.log('SERVER_STARTED');

--- a/test/ioc/DecoratorInheritance.test.ts
+++ b/test/ioc/DecoratorInheritance.test.ts
@@ -121,6 +121,13 @@ describe('@PostConstruct inheritance', () => {
 
   const register = async (classes: Class[]) => {
     await engine.searchAndRegister(classes.map((Class) => ({ Class, interface: null }) as InjectableComponent));
+
+    // Start hooks are deferred to server.start(), which these tests do not go through - they
+    // are about which hooks the inheritance chain yields, not about when they fire. Drive them
+    // the way LifecycleService does.
+    for (const component of engine.container.lifecycle) {
+      await engine.container.executeStartHooks(component.instance, component.Class);
+    }
   };
 
   test('runs hooks from every level of the chain', async () => {

--- a/test/ioc/InjectedFieldAssignment.test.ts
+++ b/test/ioc/InjectedFieldAssignment.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { InjectableComponent } from '../../lib/ioc';
+import type { Class } from '../../lib/server/types';
+import { Container, IocEngine } from '../../lib/ioc';
+import { Implements, Inject, Strategy } from '../../lib/ioc/component';
+import { Service } from '../../lib/server/decorators';
+
+/**
+ * Injected fields are accessors with no setter, which is a good property - the container owns
+ * them. But the engine's own message for that ("Attempted to assign to readonly property.")
+ * names neither the field nor the class nor the supported alternative, so the first person to
+ * reach for `Object.assign(instance, {dep: double})` in a test spends a run working out what it
+ * is telling them.
+ */
+@Service()
+class OutboxWriter {
+  public append(): string {
+    return 'real';
+  }
+}
+
+@Service()
+class NotificationService {
+  @Inject(OutboxWriter)
+  private outbox: OutboxWriter;
+
+  public notify(): string {
+    return this.outbox.append();
+  }
+}
+
+@Service()
+@Implements('IChannel')
+class EmailChannel {}
+
+@Service()
+class Broadcaster {
+  @Strategy('IChannel')
+  private channels: unknown[];
+
+  public count(): number {
+    return this.channels.length;
+  }
+}
+
+describe('assigning to an injected field', () => {
+  let engine: IocEngine;
+
+  beforeEach(async () => {
+    engine = new IocEngine();
+    (engine as any)['_container'] = new Container();
+
+    const classes: Class[] = [OutboxWriter, NotificationService, EmailChannel, Broadcaster];
+
+    await engine.searchAndRegister(classes.map((Class) => ({ Class, interface: null }) as InjectableComponent));
+  });
+
+  test('names the field, the class and the way out for @Inject', async () => {
+    const service: any = await engine.container.resolve('NotificationService');
+
+    expect(() => Object.assign(service, { outbox: { append: () => 'double' } })).toThrow(
+      "Cannot assign to 'outbox' on NotificationService: fields wired by @Inject are read-only.",
+    );
+
+    expect(() => Object.assign(service, { outbox: {} })).toThrow(/createTestApp\(\)\/createWebTest\(\)/);
+    expect(() => Object.assign(service, { outbox: {} })).toThrow(/mockComponent\(\)/);
+  });
+
+  test('does the same for @Strategy', async () => {
+    const broadcaster: any = await engine.container.resolve('Broadcaster');
+
+    expect(() => Object.assign(broadcaster, { channels: [] })).toThrow(
+      "Cannot assign to 'channels' on Broadcaster: fields wired by @Strategy are read-only.",
+    );
+  });
+
+  test('leaves the real dependency in place after a refused assignment', async () => {
+    const service: any = await engine.container.resolve('NotificationService');
+
+    expect(() => Object.assign(service, { outbox: { append: () => 'double' } })).toThrow();
+    expect(service.notify()).toBe('real');
+  });
+});

--- a/test/ioc/inheritance.test.ts
+++ b/test/ioc/inheritance.test.ts
@@ -28,6 +28,12 @@ describe('Inheritance Tests', () => {
 
     await iocEngine.searchAndRegister(components);
 
+    // Start hooks now run from server.start(); this test drives the engine directly, so it has
+    // to run them itself before asserting on what a @PostConstruct set up.
+    for (const component of iocEngine.container.lifecycle) {
+      await iocEngine.container.executeStartHooks(component.instance, component.Class);
+    }
+
     const service1 = (await iocEngine.container.resolve<InheritedService1Test>(
       'InheritedService1Test',
     )) as InheritedService1Test;

--- a/test/lifecycle/ConfigDependencyStart.test.ts
+++ b/test/lifecycle/ConfigDependencyStart.test.ts
@@ -1,0 +1,396 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { AsenaServerFactory } from '../../lib/server';
+import { Config, Controller, Middleware, Service } from '../../lib/server/decorators';
+import { Get } from '../../lib/server/web/decorators';
+import { Inject, OnStart } from '../../lib/ioc/component';
+import { AsenaMiddlewareService } from '../../lib/server/web/middleware';
+import { silentLogger } from '../../lib/test/harness/silentLogger';
+import { createMockAdapter } from '../utils/createMockContext';
+
+/**
+ * Where a @Config's *dependencies* stand when its hooks are read: started, all of them.
+ *
+ * This file exists because that was briefly not true, and nothing caught it. When `@OnStart`
+ * moved out of `Container.register()` it landed *after* APPLICATION_SETUP, which is where the
+ * framework reads the config. Topological order still guaranteed the injected component was
+ * **constructed** before the config - it no longer guaranteed the component had **started**.
+ *
+ * The damage ran along one line: whether the framework *calls* a config hook during setup or
+ * merely *binds* it and calls it per request.
+ *
+ *   called during setup  -> serveOptions(), globalMiddlewares(), transport()   <- broke
+ *   bound, called later  -> onError(), onNotFound()                            <- fine either way
+ *
+ * `transport()` was the worst of them, and it is the shape the redis and kafka packages
+ * document: `prepareMicroservices()` goes on to `init()` and `listen()` whatever it returned, so
+ * a transport built from an injected service reached for a connection whose `@OnStart` had not
+ * opened it, and the boot died pointing at the wrong component. The other two failed silently.
+ *
+ * `start()` now runs the hooks before application setup. These tests hold that line: four of
+ * them fail if it ever moves back down, and the last one fails if it moves too far up, past the
+ * point where the socket binds.
+ */
+
+const events: string[] = [];
+
+/**
+ * Models the shape every connection-owning framework package uses: a component that is inert
+ * until its start hook runs, and whose accessor refuses to hand out a half-built resource
+ * rather than returning undefined. `AsenaRedisService.client` is exactly this.
+ */
+@Service()
+class ConnectionService {
+  private client: string | null = null;
+
+  public statusTable: Record<string, number> = {};
+
+  @OnStart()
+  public async connect() {
+    this.client = 'connected';
+    this.statusTable = { NOT_FOUND: 404 };
+    events.push('connection:start');
+  }
+
+  public get started(): boolean {
+    return this.client !== null;
+  }
+
+  public getClient(): string {
+    if (!this.client) {
+      throw new Error('Connection not initialized. Service may not have started properly.');
+    }
+
+    return this.client;
+  }
+}
+
+/**
+ * A transport built from the injected service, borrowing its connection in `init()` - the
+ * shape `RedisMicroserviceTransport` and `KafkaMicroserviceTransport` both have. The
+ * constructor only stores the reference, so the damage does not surface until `init()`.
+ */
+class BorrowingTransport {
+  public readonly source: ConnectionService;
+
+  public constructor(source: ConnectionService) {
+    this.source = source;
+  }
+
+  public async init(): Promise<void> {
+    events.push(`transport:init(${this.source.getClient()})`);
+  }
+
+  public async listen(): Promise<void> {
+    events.push('transport:listen');
+  }
+
+  public async send(): Promise<void> {}
+
+  public async close(): Promise<void> {}
+
+  public registerHandler(): void {}
+}
+
+/**
+ * A mock adapter that matches how the shipped adapters treat each hook, because that is what
+ * decides whether a hook body runs during setup or later:
+ * - `serveOptions(fn)` invokes `fn` immediately (both HonoAdapter and Ergenecore do)
+ * - `onError(fn)` / `onNotFound(fn)` only store `fn`; the router calls it per request
+ */
+const createConfigAwareAdapter = () => {
+  const { adapter } = createMockAdapter();
+  const captured: { onError?: any; onNotFound?: any } = {};
+
+  (adapter as any).serveOptions = mock(async (options: () => any) => {
+    await options();
+  });
+  (adapter as any).onError = mock((handler: any) => {
+    captured.onError = handler;
+  });
+  (adapter as any).onNotFound = mock((handler: any) => {
+    captured.onNotFound = handler;
+  });
+  (adapter as any).getWebsocketAdapter = mock(() => undefined);
+
+  return { adapter, captured };
+};
+
+const createServer = (components: any[], adapter: any) =>
+  AsenaServerFactory.create({
+    adapter,
+    logger: silentLogger,
+    components,
+    shutdown: { signals: false },
+    keepAlive: false,
+  });
+
+describe('a @Config whose dependency carries an @OnStart', () => {
+  beforeEach(() => {
+    events.length = 0;
+  });
+
+  describe('hooks the framework calls during application setup', () => {
+    test('transport() runs against a dependency that already started', async () => {
+      const observed: { started?: boolean } = {};
+
+      @Config()
+      class TransportConfig {
+        @Inject(ConnectionService)
+        private connection: ConnectionService;
+
+        public transport() {
+          observed.started = this.connection.started;
+          events.push('config:transport');
+
+          // An inert but well-formed return: normalizeTransportConfig rejects an object with
+          // none of its known fields, and what is under test here is the timing, not the shape.
+          return { interceptors: [] };
+        }
+      }
+
+      const { adapter } = createConfigAwareAdapter();
+      const server = await createServer([ConnectionService, TransportConfig], adapter);
+
+      await server.start();
+
+      // The assertion that matters is the pair: the hook ran, and it ran second. Asserting only
+      // `started === true` would still pass if transport() were never called at all.
+      expect(events).toEqual(['connection:start', 'config:transport']);
+      expect(observed.started).toBe(true);
+
+      await server.stop();
+    });
+
+    test('a transport that borrows the dependency in init() boots', async () => {
+      // The shape the redis and kafka packages document:
+      //
+      //   public transport() {
+      //     return { microservice: new RedisMicroserviceTransport(this.redis, { ... }) };
+      //   }
+      //
+      // prepareMicroservices() calls init() in the same phase the config is read, so this only
+      // works if the connection is already open by then. It briefly was not, and the boot died
+      // with "Redis client not initialized" - naming the service rather than the ordering that
+      // actually broke it.
+      @Config()
+      class BorrowingConfig {
+        @Inject(ConnectionService)
+        private connection: ConnectionService;
+
+        public transport() {
+          return { microservice: new BorrowingTransport(this.connection) as any };
+        }
+      }
+
+      const { adapter } = createConfigAwareAdapter();
+      const server = await createServer([ConnectionService, BorrowingConfig], adapter);
+
+      await server.start();
+
+      // init() interpolates the client it fetched, so this fails with "Connection not
+      // initialized" - not merely a missing line - if the ordering ever regresses.
+      expect(events).toContain('connection:start');
+      expect(events).toContain('transport:init(connected)');
+
+      await server.stop();
+    });
+
+    test('globalMiddlewares() sees a started dependency, including a captured value', async () => {
+      const observed: { started?: boolean; table?: Record<string, number> } = {};
+
+      @Middleware()
+      class PassThroughMiddleware extends AsenaMiddlewareService {
+        public handle(_context: any, next: any) {
+          return next();
+        }
+      }
+
+      @Config()
+      class MiddlewareConfig {
+        @Inject(ConnectionService)
+        private connection: ConnectionService;
+
+        public globalMiddlewares() {
+          observed.started = this.connection.started;
+          // The capturing shape, and the reason this hook is worth a test of its own: a value
+          // read here is frozen at setup time. There is no later read to save it, so if the
+          // dependency were cold this would silently compute a middleware list from nothing.
+          observed.table = { ...this.connection.statusTable };
+          events.push('config:globalMiddlewares');
+
+          return [PassThroughMiddleware];
+        }
+      }
+
+      const { adapter } = createConfigAwareAdapter();
+      const server = await createServer([ConnectionService, PassThroughMiddleware, MiddlewareConfig], adapter);
+
+      await server.start();
+
+      expect(events).toEqual(['connection:start', 'config:globalMiddlewares']);
+      expect(observed.started).toBe(true);
+      expect(observed.table).toEqual({ NOT_FOUND: 404 });
+
+      await server.stop();
+    });
+
+    test('serveOptions() sees a started dependency', async () => {
+      const observed: { started?: boolean } = {};
+
+      @Config()
+      class ServeOptionsConfig {
+        @Inject(ConnectionService)
+        private connection: ConnectionService;
+
+        public serveOptions() {
+          observed.started = this.connection.started;
+          events.push('config:serveOptions');
+
+          return {};
+        }
+      }
+
+      const { adapter } = createConfigAwareAdapter();
+      const server = await createServer([ConnectionService, ServeOptionsConfig], adapter);
+
+      await server.start();
+
+      // Both shipped adapters `await options()` rather than storing the callback, so this hook
+      // is genuinely called during setup - the mock adapter here models that on purpose. A mock
+      // that only stored it would report this hook as safe no matter what the ordering did.
+      expect(events).toEqual(['connection:start', 'config:serveOptions']);
+      expect(observed.started).toBe(true);
+
+      await server.stop();
+    });
+  });
+
+  describe('hooks the framework only binds during setup', () => {
+    test('onError() and onNotFound() run against a started dependency', async () => {
+      const observed: { onError?: boolean; onNotFound?: boolean } = {};
+
+      @Config()
+      class HandlerConfig {
+        @Inject(ConnectionService)
+        private connection: ConnectionService;
+
+        public onError(_error: Error, context: any) {
+          observed.onError = this.connection.started;
+
+          return context.send({ status: this.connection.statusTable.NOT_FOUND }, 500);
+        }
+
+        public onNotFound(context: any) {
+          observed.onNotFound = this.connection.started;
+
+          return context.send({ status: this.connection.statusTable.NOT_FOUND }, 404);
+        }
+      }
+
+      const { adapter, captured } = createConfigAwareAdapter();
+      const server = await createServer([ConnectionService, HandlerConfig], adapter);
+
+      await server.start();
+
+      // Registered during setup, invoked now - which is the whole reason these two are safe.
+      const send = mock((data: any, status?: number) => ({ data, status }));
+
+      await captured.onError!(new Error('boom'), { send });
+      await captured.onNotFound!({ send }, { path: '/missing', method: 'GET' });
+
+      expect(observed.onError).toBe(true);
+      expect(observed.onNotFound).toBe(true);
+
+      // Reading through to the value proves the dependency was usable, not merely flagged
+      // started. A stale read would have produced `undefined` here.
+      expect(send.mock.calls).toEqual([
+        [{ status: 404 }, 500],
+        [{ status: 404 }, 404],
+      ]);
+
+      await server.stop();
+    });
+
+    test('a global middleware and a controller both see a started dependency', async () => {
+      const observed: { middleware?: boolean; controller?: boolean; client?: string } = {};
+
+      @Middleware()
+      class ConnectionMiddleware extends AsenaMiddlewareService {
+        @Inject(ConnectionService)
+        private connection: ConnectionService;
+
+        public handle(_context: any, next: any) {
+          observed.middleware = this.connection.started;
+
+          return next();
+        }
+      }
+
+      @Controller('/api')
+      class PingController {
+        @Inject(ConnectionService)
+        private connection: ConnectionService;
+
+        @Get('/ping')
+        public ping(context: any) {
+          observed.controller = this.connection.started;
+          // Read through to the resource rather than the flag: `getClient()` throws when the
+          // start hook has not run, so this line is the assertion the handler makes itself.
+          observed.client = this.connection.getClient();
+
+          return context.send(observed.client);
+        }
+      }
+
+      @Config()
+      class RequestTimeConfig {
+        public globalMiddlewares() {
+          return [ConnectionMiddleware];
+        }
+      }
+
+      const { adapter } = createConfigAwareAdapter();
+      const server = await createServer(
+        [ConnectionService, ConnectionMiddleware, PingController, RequestTimeConfig],
+        adapter,
+      );
+
+      await server.start();
+
+      // A real trip through the adapter's dispatch, not a direct call on the instance: the
+      // middleware the adapter holds is a bound `handle`, and binding happens during setup.
+      // What this proves is that binding early does not capture early state.
+      await (adapter as any).testRequest('get', '/api/ping');
+
+      expect(observed.client).toBe('connected');
+      expect(observed.middleware).toBe(true);
+      expect(observed.controller).toBe(true);
+
+      await server.stop();
+    });
+
+    test('the socket binds only after every start hook has run', async () => {
+      // This is what makes the request-time path safe, and it is a property of start()'s
+      // ordering rather than of any one hook: the adapter is not asked to listen until the
+      // lifecycle has finished, so there is no window in which a request meets a cold
+      // component. Move `lifecycleService.start()` below `adapter.start()` and only this
+      // test fails - the two above would keep passing, because they drive the adapter by hand.
+      @Config()
+      class PlainConfig {}
+
+      const { adapter } = createConfigAwareAdapter();
+
+      (adapter as any).start = mock(async () => {
+        events.push('adapter:start');
+      });
+
+      const server = await createServer([ConnectionService, PlainConfig], adapter);
+
+      await server.start();
+
+      expect(events).toEqual(['connection:start', 'adapter:start']);
+
+      await server.stop();
+    });
+  });
+});

--- a/test/lifecycle/LifecycleService.test.ts
+++ b/test/lifecycle/LifecycleService.test.ts
@@ -1,0 +1,376 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { AsenaServerFactory } from '../../lib/server';
+import { PostProcessor, Service } from '../../lib/server/decorators';
+import { Inject, OnStart, OnStop, PostConstruct } from '../../lib/ioc/component';
+import { LifecycleState } from '../../lib/server/lifecycle';
+import { ICoreServiceNames } from '../../lib/ioc';
+import type { LifecycleService } from '../../lib/server/lifecycle';
+import { silentLogger } from '../../lib/test/harness/silentLogger';
+import { createMockAdapter } from '../utils/createMockContext';
+
+const events: string[] = [];
+
+const createServer = (components: any[]) =>
+  AsenaServerFactory.create({
+    adapter: createMockAdapter().adapter as any,
+    logger: silentLogger,
+    components,
+    shutdown: { signals: false },
+    keepAlive: false,
+  });
+
+describe('lifecycle hooks', () => {
+  beforeEach(() => {
+    events.length = 0;
+  });
+
+  describe('ordering', () => {
+    @Service()
+    class Database {
+      @OnStart()
+      public async open() {
+        events.push('database:start');
+      }
+
+      @OnStop()
+      public async close() {
+        events.push('database:stop');
+      }
+    }
+
+    @Service()
+    class Repository {
+      @Inject(Database)
+      private database: Database;
+
+      @OnStart()
+      public async warm() {
+        events.push(`repository:start(${this.database ? 'wired' : 'unwired'})`);
+      }
+
+      @OnStop()
+      public async flush() {
+        events.push('repository:stop');
+      }
+    }
+
+    test('starts dependencies first and stops them last', async () => {
+      // Declared dependent-first on purpose: the order that matters is the topological one the
+      // IoC engine computes, not the order the components were handed in.
+      const server = await createServer([Repository, Database]);
+
+      await server.start();
+
+      expect(events).toEqual(['database:start', 'repository:start(wired)']);
+
+      await server.stop();
+
+      expect(events).toEqual(['database:start', 'repository:start(wired)', 'repository:stop', 'database:stop']);
+    });
+
+    test('runs no hook before start()', async () => {
+      await createServer([Repository, Database]);
+
+      expect(events).toEqual([]);
+    });
+  });
+
+  describe('@PostConstruct alias', () => {
+    @Service()
+    class Legacy {
+      @PostConstruct()
+      public async init() {
+        events.push('legacy:start');
+      }
+    }
+
+    test('still runs, on the same schedule as @OnStart', async () => {
+      const server = await createServer([Legacy]);
+
+      expect(events).toEqual([]);
+
+      await server.start();
+
+      expect(events).toEqual(['legacy:start']);
+
+      await server.stop();
+    });
+  });
+
+  describe('a start hook that throws', () => {
+    @Service()
+    class Healthy {
+      @OnStart()
+      public async open() {
+        events.push('healthy:start');
+      }
+
+      @OnStop()
+      public async close() {
+        events.push('healthy:stop');
+      }
+    }
+
+    @Service()
+    class Broken {
+      @Inject(Healthy)
+      private healthy: Healthy;
+
+      @OnStart()
+      public async open() {
+        events.push('broken:start');
+        throw new Error('cannot reach the thing');
+      }
+
+      @OnStop()
+      public async close() {
+        events.push('broken:stop');
+      }
+    }
+
+    test('aborts the boot, naming the hook and keeping the cause', async () => {
+      const server = await createServer([Healthy, Broken]);
+
+      const start = server.start();
+
+      await expect(start).rejects.toThrow("@OnStart hook 'Broken.open()' failed");
+      await expect(start).rejects.toHaveProperty('cause.message', 'cannot reach the thing');
+    });
+
+    test('rolls back the components that already started', async () => {
+      const server = await createServer([Healthy, Broken]);
+
+      await expect(server.start()).rejects.toThrow();
+
+      // Healthy started, so it is stopped. Broken's own @OnStop does not run: its start hook
+      // threw, so it never counted as started.
+      expect(events).toEqual(['healthy:start', 'broken:start', 'healthy:stop']);
+    });
+
+    test('leaves the lifecycle in FAILED', async () => {
+      const server = await createServer([Healthy, Broken]);
+
+      await expect(server.start()).rejects.toThrow();
+
+      const lifecycle = await server.resolve<LifecycleService>(ICoreServiceNames.LIFECYCLE_SERVICE);
+
+      expect(lifecycle.state).toBe(LifecycleState.FAILED);
+    });
+
+    test('does not run a rolled-back hook again on stop()', async () => {
+      const server = await createServer([Healthy, Broken]);
+
+      await expect(server.start()).rejects.toThrow();
+
+      events.length = 0;
+      await server.stop();
+
+      expect(events).toEqual([]);
+    });
+  });
+
+  describe('a stop hook that misbehaves', () => {
+    @Service()
+    class First {
+      @OnStop()
+      public async close() {
+        events.push('first:stop');
+      }
+    }
+
+    @Service()
+    class Exploding {
+      @Inject(First)
+      private first: First;
+
+      @OnStop()
+      public async close() {
+        events.push('exploding:stop');
+        throw new Error('nope');
+      }
+    }
+
+    @Service()
+    class Hanging {
+      @Inject(Exploding)
+      private exploding: Exploding;
+
+      @OnStop()
+      public async close() {
+        events.push('hanging:stop');
+
+        return new Promise<void>(() => {});
+      }
+    }
+
+    test('does not stop the rest of the shutdown', async () => {
+      const server = await createServer([First, Exploding, Hanging]);
+
+      await server.start();
+      events.length = 0;
+
+      await server.stop({ hookTimeout: 50 });
+
+      // Every hook was given its turn, in reverse order, despite one throwing and one hanging.
+      expect(events).toEqual(['hanging:stop', 'exploding:stop', 'first:stop']);
+    });
+  });
+
+  describe('stop() without a successful start', () => {
+    @Service()
+    class NeverStarted {
+      @OnStop()
+      public async close() {
+        events.push('never-started:stop');
+      }
+    }
+
+    test('runs nothing when start() was never called', async () => {
+      const server = await createServer([NeverStarted]);
+
+      await server.stop();
+
+      expect(events).toEqual([]);
+    });
+
+    test('still stops a post-processor, which starts at construction', async () => {
+      // The rule is per component, not "nothing runs on a server that never started". A
+      // post-processor's start hook fires during the scan - it has to, because postProcess()
+      // reads what it sets up - so by the time create() returns it has already acquired
+      // whatever it acquires. The otel processor builds its tracer and meter providers there.
+      // A boot that fails before start() must still release them.
+      @PostProcessor({ name: 'AcquiringProcessor' })
+      class AcquiringProcessor {
+        public postProcess<T>(instance: T): T {
+          return instance;
+        }
+
+        @OnStop()
+        public release() {
+          events.push('postprocessor:stop');
+        }
+      }
+
+      const server = await createServer([AcquiringProcessor, NeverStarted]);
+
+      await server.stop();
+
+      // The ordinary component never started, so it is not stopped. The post-processor did.
+      expect(events).toEqual(['postprocessor:stop']);
+    });
+
+    test('is idempotent', async () => {
+      const server = await createServer([NeverStarted]);
+
+      await server.start();
+      events.length = 0;
+
+      await server.stop();
+      await server.stop();
+
+      expect(events).toEqual(['never-started:stop']);
+    });
+
+    test('does not re-run the framework teardown on a later stop()', async () => {
+      const server = await createServer([NeverStarted]);
+
+      await server.start();
+
+      // The component hooks would find nothing to do either way - what this pins is the rest
+      // of the sequence. The adapter, the cron runner and the transports are not self-guarding,
+      // so a stop() that re-walked them would tear down an already-stopped server a second time.
+      const adapter = (server as any)._adapter;
+      let adapterStops = 0;
+      const original = adapter.stop.bind(adapter);
+
+      adapter.stop = (...args: unknown[]) => {
+        adapterStops++;
+
+        return original(...args);
+      };
+
+      await server.stop();
+      await server.stop();
+      await server.stop();
+
+      expect(adapterStops).toBe(1);
+    });
+
+    test('runs concurrent stops as one shutdown', async () => {
+      const server = await createServer([NeverStarted]);
+
+      await server.start();
+      events.length = 0;
+
+      await Promise.all([server.stop(), server.stop(), server.stop()]);
+
+      expect(events).toEqual(['never-started:stop']);
+    });
+  });
+
+  describe('a teardown step that throws', () => {
+    @Service()
+    class Releasable {
+      @OnStop()
+      public async close() {
+        events.push('releasable:stop');
+      }
+    }
+
+    test('does not strand the steps behind it', async () => {
+      const server = await createServer([Releasable]);
+
+      await server.start();
+      events.length = 0;
+
+      // The adapter is the step most likely to fail for reasons outside the application's
+      // control, and everything that releases a real resource sits behind it.
+      const adapter = (server as any)._adapter;
+      const original = adapter.stop.bind(adapter);
+
+      adapter.stop = () => Promise.reject(new Error('socket refused to close'));
+
+      await expect(server.stop()).rejects.toThrow('shutdown completed with 1 failure');
+
+      // The stop hook ran anyway - that is the whole point.
+      expect(events).toEqual(['releasable:stop']);
+
+      adapter.stop = original;
+    });
+  });
+
+  describe('state', () => {
+    @Service()
+    class Plain {}
+
+    test('walks NEW -> STARTED -> STOPPED', async () => {
+      const server = await createServer([Plain]);
+      const lifecycle = await server.resolve<LifecycleService>(ICoreServiceNames.LIFECYCLE_SERVICE);
+
+      expect(lifecycle.state).toBe(LifecycleState.NEW);
+
+      await server.start();
+      expect(lifecycle.state).toBe(LifecycleState.STARTED);
+
+      await server.stop();
+      expect(lifecycle.state).toBe(LifecycleState.STOPPED);
+    });
+  });
+
+  describe('server.resolve()', () => {
+    @Service()
+    class Resolvable {
+      public readonly marker = 'resolved';
+    }
+
+    test('reaches a component without going through coreContainer', async () => {
+      const server = await createServer([Resolvable]);
+
+      await server.start();
+
+      expect(await server.resolve<Resolvable>('Resolvable')).toHaveProperty('marker', 'resolved');
+
+      await server.stop();
+    });
+  });
+});

--- a/test/lifecycle/LifecycleWarnings.test.ts
+++ b/test/lifecycle/LifecycleWarnings.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { AsenaServerFactory } from '../../lib/server';
+import { Config, Service } from '../../lib/server/decorators';
+import { OnStart, OnStop, Scope } from '../../lib/ioc/component';
+import { silentLogger } from '../../lib/test/harness/silentLogger';
+import { createMockAdapter } from '../utils/createMockContext';
+
+const warnings: string[] = [];
+
+const capturingLogger = {
+  ...silentLogger,
+  warn: (message: string) => {
+    warnings.push(message);
+  },
+};
+
+const createServer = (components: any[]) =>
+  AsenaServerFactory.create({
+    adapter: createMockAdapter().adapter as any,
+    logger: capturingLogger as any,
+    components,
+    shutdown: { signals: false },
+    keepAlive: false,
+  });
+
+describe('lifecycle warnings', () => {
+  beforeEach(() => {
+    warnings.length = 0;
+  });
+
+  test('a transient with @OnStop is called out at boot', async () => {
+    @Service({ scope: Scope.PROTOTYPE })
+    class PerResolveWorker {
+      @OnStop()
+      public async close() {}
+    }
+
+    await createServer([PerResolveWorker]);
+
+    const warning = warnings.find((message) => message.includes('PerResolveWorker'));
+
+    expect(warning).toContain('transient');
+    expect(warning).toContain('@OnStop');
+    expect(warning).toContain('never');
+  });
+
+  test('a singleton with @OnStop is not', async () => {
+    @Service()
+    class SingletonWorker {
+      @OnStop()
+      public async close() {}
+    }
+
+    await createServer([SingletonWorker]);
+
+    expect(warnings.filter((message) => message.includes('SingletonWorker'))).toEqual([]);
+  });
+
+  test('a @Config with a start hook is called out', async () => {
+    @Config()
+    class AppConfig {
+      @OnStart()
+      public prepare() {}
+    }
+
+    const server = await createServer([AppConfig]);
+
+    await server.start();
+
+    const warning = warnings.find((message) => message.includes('AppConfig'));
+
+    expect(warning).toContain('start hook');
+    expect(warning).toContain('application setup');
+
+    await server.stop();
+  });
+
+  test('a @Config without one is not', async () => {
+    @Config()
+    class QuietConfig {}
+
+    const server = await createServer([QuietConfig]);
+
+    await server.start();
+
+    expect(warnings.filter((message) => message.includes('QuietConfig'))).toEqual([]);
+
+    await server.stop();
+  });
+});

--- a/test/lifecycle/LifecycleWarnings.test.ts
+++ b/test/lifecycle/LifecycleWarnings.test.ts
@@ -56,34 +56,33 @@ describe('lifecycle warnings', () => {
     expect(warnings.filter((message) => message.includes('SingletonWorker'))).toEqual([]);
   });
 
-  test('a @Config with a start hook is called out', async () => {
+  test('a @Config with a start hook is not warned about, because it works', async () => {
+    // There used to be a warning here, and it was right at the time: start hooks ran after
+    // application setup, so a @Config's own hook fired after its config hooks had been read.
+    // Moving the hooks ahead of setup made the warning false - the hook now runs first and can
+    // prepare what transport() or globalMiddlewares() goes on to use.
+    const prepared: string[] = [];
+
     @Config()
     class AppConfig {
       @OnStart()
-      public prepare() {}
+      public prepare() {
+        prepared.push('config:start');
+      }
+
+      public globalMiddlewares() {
+        prepared.push(`config:middlewares(${prepared.includes('config:start') ? 'prepared' : 'cold'})`);
+
+        return [];
+      }
     }
 
     const server = await createServer([AppConfig]);
 
     await server.start();
 
-    const warning = warnings.find((message) => message.includes('AppConfig'));
-
-    expect(warning).toContain('start hook');
-    expect(warning).toContain('application setup');
-
-    await server.stop();
-  });
-
-  test('a @Config without one is not', async () => {
-    @Config()
-    class QuietConfig {}
-
-    const server = await createServer([QuietConfig]);
-
-    await server.start();
-
-    expect(warnings.filter((message) => message.includes('QuietConfig'))).toEqual([]);
+    expect(warnings.filter((message) => message.includes('AppConfig'))).toEqual([]);
+    expect(prepared).toEqual(['config:start', 'config:middlewares(prepared)']);
 
     await server.stop();
   });

--- a/test/lifecycle/PostProcessorImmediate.test.ts
+++ b/test/lifecycle/PostProcessorImmediate.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { ComponentPostProcessor } from '../../lib/ioc';
+import { AsenaServerFactory } from '../../lib/server';
+import { PostProcessor, Service } from '../../lib/server/decorators';
+import { OnStart } from '../../lib/ioc/component';
+import { silentLogger } from '../../lib/test/harness/silentLogger';
+import { createMockAdapter } from '../utils/createMockContext';
+
+/**
+ * The one exception to deferred start hooks, pinned.
+ *
+ * A post-processor's `postProcess()` reads state its own start hook sets up - the otel
+ * processor captures `this.tracer` at wrap time, so a deferred hook would hand every wrapped
+ * component an undefined tracer and every traced call would throw. The IoC engine therefore
+ * registers post-processors (and their dependency closure) in a first phase that keeps the
+ * original timing, and only defers the user components in the second.
+ *
+ * If this test goes red, every @PostProcessor package breaks in a way unit tests elsewhere
+ * will not notice: silently, at the first call into a wrapped component.
+ */
+const observed: string[] = [];
+
+@PostProcessor({ name: 'CapturingPostProcessor' })
+class CapturingPostProcessor implements ComponentPostProcessor {
+  private stamp?: string;
+
+  @OnStart()
+  public init(): void {
+    observed.push('postprocessor:start');
+    this.stamp = 'ready';
+  }
+
+  public postProcess<T>(instance: T, Class: any): T {
+    // The read that matters: whatever the start hook set has to be here already.
+    observed.push(`postProcess(${Class.name}):${this.stamp ?? 'UNINITIALISED'}`);
+
+    return instance;
+  }
+}
+
+@Service()
+class Ordinary {
+  @OnStart()
+  public start(): void {
+    observed.push('ordinary:start');
+  }
+}
+
+describe('post-processor start hooks', () => {
+  beforeEach(() => {
+    observed.length = 0;
+  });
+
+  test('run at construction, before anything they process', async () => {
+    const server = await AsenaServerFactory.create({
+      adapter: createMockAdapter().adapter as any,
+      logger: silentLogger,
+      components: [CapturingPostProcessor, Ordinary],
+      shutdown: { signals: false },
+      keepAlive: false,
+    });
+
+    // Already ran during create(): the post-processor is initialised and has wrapped Ordinary,
+    // while Ordinary's own hook is still waiting for start(). AsenaServer is in the list too -
+    // it is registered last and goes through the same post-processing.
+    expect(observed[0]).toBe('postprocessor:start');
+    expect(observed).toContain('postProcess(Ordinary):ready');
+    expect(observed).not.toContain('ordinary:start');
+
+    await server.start();
+
+    expect(observed.at(-1)).toBe('ordinary:start');
+
+    await server.stop();
+  });
+
+  test('never observes an uninitialised processor', async () => {
+    const server = await AsenaServerFactory.create({
+      adapter: createMockAdapter().adapter as any,
+      logger: silentLogger,
+      components: [CapturingPostProcessor, Ordinary],
+      shutdown: { signals: false },
+      keepAlive: false,
+    });
+
+    await server.start();
+
+    expect(observed.filter((entry) => entry.includes('UNINITIALISED'))).toEqual([]);
+
+    await server.stop();
+  });
+});

--- a/test/server/health/HealthProbes.test.ts
+++ b/test/server/health/HealthProbes.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { AsenaServerFactory } from '../../../lib/server';
+import { Service } from '../../../lib/server/decorators';
+import { OnStop } from '../../../lib/ioc/component';
+import { silentLogger } from '../../../lib/test/harness/silentLogger';
+
+let server: any;
+
+// 10000-31999: above the well-known range and below the kernel's ephemeral floor
+// (net.ipv4.ip_local_port_range, 32768-60999). A server port drawn from that range collides
+// with the outbound sockets the suite itself holds open - TIME_WAIT included - and Bun.serve
+// then fails with EADDRINUSE, randomly, in whichever test happened to draw it.
+const randomPort = () => 10000 + Math.floor(Math.random() * 22000);
+
+const createHeadless = async (components: any[] = []) => {
+  const port = randomPort();
+
+  server = await AsenaServerFactory.create({
+    headless: true,
+    logger: silentLogger,
+    components,
+    health: { port },
+    shutdown: { signals: false },
+  });
+
+  await server.start();
+
+  return port;
+};
+
+describe('health probes', () => {
+  afterEach(async () => {
+    await server?.stop();
+    server = undefined;
+  });
+
+  test('serves /live, /ready and the base path', async () => {
+    const port = await createHeadless();
+
+    const live = await fetch(`http://localhost:${port}/healthz/live`);
+    const ready = await fetch(`http://localhost:${port}/healthz/ready`);
+    const base = await fetch(`http://localhost:${port}/healthz`);
+
+    expect(live.status).toBe(200);
+    expect(ready.status).toBe(200);
+    expect(base.status).toBe(200);
+
+    expect(await live.json()).toMatchObject({ status: 'up' });
+  });
+
+  test('still 404s an unknown path', async () => {
+    const port = await createHeadless();
+
+    expect((await fetch(`http://localhost:${port}/healthz/nope`)).status).toBe(404);
+    expect((await fetch(`http://localhost:${port}/other`)).status).toBe(404);
+  });
+
+  test('reports not ready while shutting down, and stays live', async () => {
+    // A stop hook that takes its time is what gives the probe a window to be observed in -
+    // and is exactly the situation the split exists for: the instance is draining, so it must
+    // be pulled from rotation, but it has not died and must not be restarted.
+    @Service()
+    class SlowToStop {
+      @OnStop()
+      public async close() {
+        await Bun.sleep(300);
+      }
+    }
+
+    const port = await createHeadless([SlowToStop]);
+
+    const stopping = server.stop();
+
+    await Bun.sleep(50);
+
+    const ready = await fetch(`http://localhost:${port}/healthz/ready`);
+    const live = await fetch(`http://localhost:${port}/healthz/live`);
+
+    // Pulled from rotation but not restarted: that distinction is the whole reason the two
+    // probes are separate, and it only holds because the health server is the last thing
+    // stop() takes down.
+    expect(ready.status).toBe(503);
+    expect(await ready.json()).toMatchObject({ status: 'not_ready', state: 'STOPPING' });
+    expect(live.status).toBe(200);
+
+    await stopping;
+    server = undefined;
+  });
+});


### PR DESCRIPTION
## Why

`@PostConstruct` ran inside `Container.register()` — in the middle of the component scan, against a half-built graph, before the microservice transports existed. And it had no counterpart, so nothing a hook acquired was ever released: every framework package that opens a connection leaked it past `server.stop()` (database pools, redis sockets, the kafka producer, OTel's exporter timers).

Reported from downstream: a test suite where each file builds a container and calls `app.stop()` accumulated pools until Postgres answered `sorry, too many clients already` — landing in whichever file happened to run last, so it read as *that* file being broken.

## What

Both halves now live in a `LifecycleService` driven by `start()` and `stop()`.

**`@OnStart`** — the new name for `@PostConstruct`, which stays as a deprecated alias writing the same metadata key. No migration beyond the import. It runs after every component is constructed and after application setup, so a hook can publish through `ulak`; and before the socket binds, so no request can reach a component whose hook has not run. Order is the topological one the IoC engine already computed.

**`@OnStop`** — new. Reverse order, HTTP surface already down, transports still up. A hook that throws or exceeds its timeout is logged and skipped; one component failing to let go must not strand the rest. Only components whose start hook completed are stopped.

`@PostProcessor` components keep construction-time timing — `postProcess()` reads what their own start hook sets up. A regression test pins it.

## Breaking

- Start hooks no longer run during registration. A component resolved from a server that was created but never started is no longer initialised.
- A failing start hook throws (naming the hook, original error as `cause`) instead of calling `process.exit(1)` — the thing that turned one broken component into a suite reporting `0 pass / 1 fail`.
- `SIGTERM`, `SIGINT` and `SIGHUP` are handled by default. Opt out with `shutdown: { signals: false }`.

## Also

- `stop({ closeActiveConnections, drainTimeout, hookTimeout })`; the boolean form still works. `drainTimeout` was previously unreachable from `stop()`. Each teardown step is contained, so one failure cannot strand the steps behind it, and `ulak.dispose()` is called for us.
- `keepAlive` holds the event loop open for a headless process, so a worker can start its loop in `@OnStart`, return, and stay alive — the entry file no longer blocks on it.
- `server.resolve(name)`, matching the harness's `app.resolve()`.
- `{path}/live` and `{path}/ready` on the headless health endpoint, wired to the lifecycle state. The health server outlives the drain, so `/ready` answers 503 for the whole shutdown.
- Assigning to an `@Inject`/`@Strategy` field now names the field and the class and points at `overrides` / `mockComponent()`.

This also carries the previously unreleased `HttpException` unification, so the release is `0.10.0`.

## Verification

- Clean `rm -rf node_modules && bun install` → **1088 tests pass**, `bun run build` and `bun run typecheck` clean, `bun run check` 0 errors.
- `test/integration/GracefulShutdown.test.ts` spawns real processes and sends real signals: a headless worker survives `start()` returning, SIGTERM/SIGINT run the stop hooks and exit 0, a throwing stop hook does not strand the components behind it, and `forceExitAfter` ends a process a hook will not let go of.
- Verified end to end against a real application built from published tarballs: `pool: { max: 3 }` produced exactly 3 Postgres backends and 0 after Ctrl+C, and an unreachable OTLP collector logged `tracer provider shutdown failed, continuing: ECONNREFUSED` while the process still exited 0 — that scenario used to exit 1 on an unhandled rejection.

## Follow-up

Dependent packages still declare `@asenajs/asena@^0.9.x` and become uninstallable alongside this until their own PRs widen the range to `^0.10.0`. They follow immediately after this one.