### PR TITLE
fix(lifecycle): drain in-flight requests on a signal shutdown

### DIFF
--- a/.changeset/signal-shutdown-drains-inflight.md
+++ b/.changeset/signal-shutdown-drains-inflight.md
@@ -1,0 +1,9 @@
+---
+"@asenajs/asena": patch
+---
+
+Graceful shutdown drains in-flight HTTP requests
+
+- A signal-triggered shutdown now stops the HTTP adapter with drain instead of force-closing active connections; an orchestrator's SIGTERM means "drain and go", and `forceExitAfter` still bounds the wait
+- New `shutdown.closeActiveConnections` (default `false` on the signal path) and `shutdown.drainTimeout` options configure the behavior; explicit `server.stop()` calls keep their own default unchanged
+- `stop()` now warns when a later call asks for a different draining mode than a shutdown already in progress, instead of silently letting the latch swallow it

--- a/.changeset/signal-shutdown-drains-inflight.md
+++ b/.changeset/signal-shutdown-drains-inflight.md
@@ -1,9 +1,0 @@
----
-"@asenajs/asena": patch
----
-
-Graceful shutdown drains in-flight HTTP requests
-
-- A signal-triggered shutdown now stops the HTTP adapter with drain instead of force-closing active connections; an orchestrator's SIGTERM means "drain and go", and `forceExitAfter` still bounds the wait
-- New `shutdown.closeActiveConnections` (default `false` on the signal path) and `shutdown.drainTimeout` options configure the behavior; explicit `server.stop()` calls keep their own default unchanged
-- `stop()` now warns when a later call asks for a different draining mode than a shutdown already in progress, instead of silently letting the latch swallow it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @asenajs/asena
 
+## 0.10.2
+
+### Patch Changes
+
+- 6fdd408: Graceful shutdown drains in-flight HTTP requests
+
+  - A signal-triggered shutdown now stops the HTTP adapter with drain instead of force-closing active connections; an orchestrator's SIGTERM means "drain and go", and `forceExitAfter` still bounds the wait
+  - New `shutdown.closeActiveConnections` (default `false` on the signal path) and `shutdown.drainTimeout` options configure the behavior; explicit `server.stop()` calls keep their own default unchanged
+  - `stop()` now warns when a later call asks for a different draining mode than a shutdown already in progress, instead of silently letting the latch swallow it
+
 ## 0.10.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Asena
 
-[![Version](https://img.shields.io/badge/version-0.10.1-blue.svg)](https://asena.sh)
+[![Version](https://img.shields.io/badge/version-0.10.2-blue.svg)](https://asena.sh)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](https://opensource.org/licenses/MIT)
-[![Bun Version](https://img.shields.io/badge/Bun-1.3.12%2B-blueviolet)](https://bun.sh)
+[![Bun Version](https://img.shields.io/badge/Bun-1.4%2B-blueviolet)](https://bun.sh)
 
 A high-performance IoC web framework for Bun runtime, bringing Spring Boot's automatic component discovery and field-based dependency injection to TypeScript.
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,13 +10,13 @@
       "devDependencies": {
         "@changesets/cli": "^2.31.1",
         "@types/bun": "latest",
-        "@typescript-eslint/eslint-plugin": "^8.65.0",
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/eslint-plugin": "^8.67.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^9.39.5",
         "eslint-config-prettier": "^9.1.2",
         "prettier": "^3.9.6",
         "typescript": "^5.9.3",
-        "typescript-eslint": "^8.65.0",
+        "typescript-eslint": "^8.67.0",
       },
     },
   },
@@ -97,35 +97,35 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
-    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.65.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/type-utils": "8.65.0", "@typescript-eslint/utils": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.65.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.67.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/type-utils": "8.67.0", "@typescript-eslint/utils": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.67.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ=="],
 
-    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.65.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.67.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w=="],
 
-    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.65.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.65.0", "@typescript-eslint/types": "^8.65.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.67.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.67.0", "@typescript-eslint/types": "^8.67.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw=="],
 
-    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0" } }, "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0" } }, "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg=="],
 
-    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.65.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.67.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg=="],
 
-    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/utils": "8.65.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/utils": "8.67.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q=="],
 
-    "@typescript-eslint/types": ["@typescript-eslint/types@8.65.0", "", {}, "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.67.0", "", {}, "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww=="],
 
-    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.65.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.65.0", "@typescript-eslint/tsconfig-utils": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/visitor-keys": "8.65.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.67.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.67.0", "@typescript-eslint/tsconfig-utils": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/visitor-keys": "8.67.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw=="],
 
-    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.65.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.65.0", "@typescript-eslint/types": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.67.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.67.0", "@typescript-eslint/types": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A=="],
 
-    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.65.0", "", { "dependencies": { "@typescript-eslint/types": "8.65.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.67.0", "", { "dependencies": { "@typescript-eslint/types": "8.67.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA=="],
 
-    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
@@ -145,11 +145,11 @@
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
-    "brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
+    "brace-expansion": ["brace-expansion@1.1.18", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -219,7 +219,7 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
-    "flatted": ["flatted@3.4.3", "", {}, "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ=="],
+    "flatted": ["flatted@3.4.4", "", {}, "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q=="],
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
@@ -233,7 +233,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "human-id": ["human-id@4.2.0", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA=="],
+    "human-id": ["human-id@4.2.1", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-zPGsiS+dWoTZtZ4AtpA9Y+BdSFSNWvnouNlWNoUFyAM6xHOHmdCvqO3k8AIbdamCOv4gUFUVNPf6rJFfc4UiJw=="],
 
     "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
@@ -255,7 +255,7 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
+    "js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -373,7 +373,7 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "typescript-eslint": ["typescript-eslint@8.65.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.65.0", "@typescript-eslint/parser": "8.65.0", "@typescript-eslint/typescript-estree": "8.65.0", "@typescript-eslint/utils": "8.65.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA=="],
+    "typescript-eslint": ["typescript-eslint@8.67.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.67.0", "@typescript-eslint/parser": "8.67.0", "@typescript-eslint/typescript-estree": "8.67.0", "@typescript-eslint/utils": "8.67.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -405,7 +405,7 @@
 
     "@manypkg/get-packages/fs-extra": ["fs-extra@8.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g=="],
 
-    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+    "@typescript-eslint/typescript-estree/minimatch": ["minimatch@10.2.6", "", { "dependencies": { "brace-expansion": "^5.0.8" } }, "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A=="],
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
@@ -417,13 +417,13 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
-    "read-yaml-file/js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
+    "read-yaml-file/js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "@manypkg/find-root/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
-    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
+    "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
 
     "read-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 

--- a/lib/server/AsenaServer.ts
+++ b/lib/server/AsenaServer.ts
@@ -141,6 +141,10 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
   // of the teardown, so it answers both a concurrent stop() and a later one.
   private stopping?: Promise<void>;
 
+  // What the latched teardown runs with, so a later stop() asking for the opposite draining
+  // mode can be named in a warning instead of being silently swallowed by the latch.
+  private stoppingCloseActive?: boolean;
+
   private signalHandlers = new Map<NodeJS.Signals, () => void>();
 
   private unhandledErrorHandler?: (error: unknown) => void;
@@ -272,7 +276,21 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
     // sequence again: the component hooks would correctly find nothing to do, but the adapter,
     // the cron runner and the transports are not self-guarding, so a stopped server would stop
     // itself a second time and log a second round of teardown errors.
-    this.stopping ??= this.runStop(closeActiveConnections, drainTimeout, hookTimeout);
+    if (
+      this.stopping !== undefined &&
+      this.stoppingCloseActive !== undefined &&
+      this.stoppingCloseActive !== closeActiveConnections
+    ) {
+      this._logger.warn(
+        `${yellow('[AsenaServer]')} stop(closeActiveConnections=${closeActiveConnections}) ignored: a shutdown with ` +
+          `closeActiveConnections=${this.stoppingCloseActive} is already running and the running one wins`,
+      );
+    }
+
+    if (this.stopping === undefined) {
+      this.stoppingCloseActive = closeActiveConnections;
+      this.stopping = this.runStop(closeActiveConnections, drainTimeout, hookTimeout);
+    }
 
     return this.stopping;
   }
@@ -500,7 +518,12 @@ export class AsenaServer<A extends AsenaAdapter<any, any>> implements ICoreServi
       forceTimer.unref?.();
     }
 
-    void this.stop()
+    // A signal means "drain and go" - an explicit stop() keeps its own (force-close) default,
+    // so test suites and programmatic callers see unchanged behavior.
+    void this.stop({
+      closeActiveConnections: this._shutdown?.closeActiveConnections ?? false,
+      drainTimeout: this._shutdown?.drainTimeout,
+    })
       .catch((error: unknown) => {
         this._logger.error(`${yellow('[AsenaServer]')} shutdown failed: ${describeError(error)}`);
       })

--- a/lib/server/types/ShutdownOptions.ts
+++ b/lib/server/types/ShutdownOptions.ts
@@ -53,6 +53,23 @@ export interface ShutdownOptions {
    * @default false
    */
   onUnhandledError?: boolean;
+
+  /**
+   * What a signal-triggered shutdown does to in-flight HTTP requests.
+   *
+   * `false` (default) drains them: an orchestrator's SIGTERM means "drain and go", and
+   * `forceExitAfter` already puts an upper bound on how long that may take. Pass `true` to
+   * close active connections immediately instead. Explicit `server.stop()` calls are not
+   * affected - their own default stays `closeActiveConnections: true`.
+   *
+   * @default false
+   */
+  closeActiveConnections?: boolean;
+
+  /**
+   * Drain budget the signal path passes to the microservice transports, in milliseconds.
+   */
+  drainTimeout?: number;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@asenajs/asena",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "LibirSoft",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
     "@types/bun": "latest",
-    "@typescript-eslint/eslint-plugin": "^8.65.0",
-    "@typescript-eslint/parser": "^8.65.0",
+    "@typescript-eslint/eslint-plugin": "^8.67.0",
+    "@typescript-eslint/parser": "^8.67.0",
     "eslint": "^9.39.5",
     "eslint-config-prettier": "^9.1.2",
     "prettier": "^3.9.6",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.65.0"
+    "typescript-eslint": "^8.67.0"
   },
   "exports": {
     ".": {

--- a/test/integration/GracefulShutdown.test.ts
+++ b/test/integration/GracefulShutdown.test.ts
@@ -121,6 +121,34 @@ describe('graceful shutdown', () => {
     expect(exitCode).toBe(0);
   }, 20_000);
 
+  test('SIGTERM drains an in-flight HTTP request instead of cutting it', async () => {
+    const worker = spawnWorker('signal-drain-server');
+    const stdout = tail(worker.stdout);
+
+    await stdout.waitFor('SERVER_STARTED');
+
+    const port = /SERVER_STARTED port=(\d+)/.exec(stdout.text())![1];
+    const request = fetch(`http://localhost:${port}/slow`);
+
+    // The signal must land while the handler is still asleep, not while the socket opens
+    await Bun.sleep(300);
+
+    worker.kill('SIGTERM');
+
+    // Force-closing active connections severs this socket: the fetch rejects with
+    // ECONNRESET instead of resolving - which is exactly how the bug shipped
+    const response = await request;
+
+    expect(response.status).toBe(200);
+    // The body only exists after the full sleep, so this is also the proof the handler
+    // ran to completion rather than being answered early
+    expect(await response.text()).toBe('drained');
+
+    const exitCode = await worker.exited;
+
+    expect(exitCode).toBe(0);
+  }, 20_000);
+
   test('a throwing stop hook does not strand the components behind it', async () => {
     const worker = spawnWorker('failing-stop-worker');
     const stdout = tail(worker.stdout);

--- a/test/integration/fixtures/signal-drain-server.ts
+++ b/test/integration/fixtures/signal-drain-server.ts
@@ -1,0 +1,95 @@
+/**
+ * An HTTP fixture for the signal-drain test: a real Bun.serve behind the real signal path.
+ *
+ * Core ships no HTTP adapter of its own, so the fixture carries the smallest one that behaves
+ * like the real ones - `stop(false)` stops listening and waits for the request in flight. The
+ * guarantee under test is core's, not the adapter's: a SIGTERM must stop() with drain rather
+ * than force-close, through any adapter that forwards the flag to Bun.
+ *
+ * Not a *.test.ts file, so the test runner does not pick it up on its own.
+ */
+import { AsenaAdapter } from '../../../lib/adapter';
+import type { RouteParams } from '../../../lib/adapter';
+import type { ServerLogger } from '../../../lib/logger';
+import { AsenaServerFactory } from '../../../lib/server';
+import { Controller } from '../../../lib/server/decorators';
+import { Get } from '../../../lib/server/web/decorators';
+import { silentLogger } from '../../../lib/test/harness/silentLogger';
+
+class DrainFixtureAdapter extends AsenaAdapter<any, any> {
+  public readonly name = 'drain-fixture';
+
+  private routes = new Map<string, RouteParams<any, any>>();
+
+  private server?: Bun.Server;
+
+  public constructor(logger: ServerLogger) {
+    super(logger);
+  }
+
+  public setPort(port: number): void {
+    this.port = port;
+  }
+
+  public registerRoute(params: RouteParams<any, any>): void {
+    // Route metadata stores the method lowercase; normalize both sides so the
+    // fixture's lookup keys agree with what fetch reports
+    const key = `${params.method.toUpperCase()} ${params.path.replace(/\/+$/, '') || '/'}`;
+
+    this.routes.set(key, params);
+  }
+
+  public async start(): Promise<Bun.Server> {
+    this.server = Bun.serve({
+      port: this.port,
+      fetch: async (request) => {
+        const { pathname } = new URL(request.url);
+
+        const route = this.routes.get(`${request.method} ${pathname.replace(/\/+$/, '') || '/'}`);
+
+        if (!route) return new Response('not found', { status: 404 });
+
+        return new Response(String(await route.handler()));
+      },
+    });
+
+    return this.server;
+  }
+
+  public async stop(closeActiveConnections = true): Promise<void> {
+    this.server?.stop(closeActiveConnections);
+    this.server = undefined;
+  }
+
+  public use(): void {}
+
+  public registerHTMLRoute(): void {}
+
+  public registerWebsocketRoute(): void {}
+
+  public onError(): void {}
+
+  public serveOptions(): void {}
+}
+
+const SLOW_MS = 800;
+
+@Controller('/slow')
+class SlowController {
+  @Get({ path: '/' })
+  public async slow(): Promise<string> {
+    await Bun.sleep(SLOW_MS);
+    return 'drained';
+  }
+}
+
+const server = await AsenaServerFactory.create({
+  adapter: new DrainFixtureAdapter(silentLogger),
+  logger: silentLogger,
+  port: 0,
+  components: [SlowController],
+});
+
+await server.start();
+
+console.log(`SERVER_STARTED port=${server.httpServer!.port} slowMs=${SLOW_MS}`);

--- a/test/ioc/Container.test.ts
+++ b/test/ioc/Container.test.ts
@@ -324,6 +324,9 @@ describe('Container', () => {
       setTimeout(resolve, 1000);
     });
 
+    // Force a full GC before measuring: bun 1.4 collects more lazily than 1.3, so without
+    // this the test measures collector timing rather than actual retention
+    Bun.gc(true);
     const finalMemory = process.memoryUsage().heapUsed;
 
     console.log('Memory used:', (finalMemory - initialMemory) / 1024);


### PR DESCRIPTION
## Summary

A signal-triggered shutdown force-closed active connections, so an in-flight HTTP request was
severed the moment SIGTERM arrived — while the process still exited `0` and logged a clean
teardown, which is what kept this invisible.

`start()` installs the core's own signal handlers, and they run before any handler the
application registers afterwards. `onShutdownSignal()` → `shutdownThenExit()` called
`this.stop()` with no arguments, and `stop()`'s default is `closeActiveConnections: true`. An
application calling `server.stop(false)` from its own handler could not win: `stop()` is latched,
so the later call returned the force-close teardown already in flight and its own intent was
silently dropped.

Not a Bun 1.4 regression — reproduced identically on 1.3.14.

## Changes

| File | Change |
|------|--------|
| `lib/server/AsenaServer.ts` | `shutdownThenExit()` stops with drain; latch warns when a later `stop()` asks for the opposite draining mode |
| `lib/server/types/ShutdownOptions.ts` | New `closeActiveConnections` (default `false` on the signal path) and `drainTimeout` |
| `test/integration/GracefulShutdown.test.ts` | Test: SIGTERM drains an in-flight request instead of cutting it |
| `test/integration/fixtures/signal-drain-server.ts` | Fixture: real process, real signal, real socket |
| `test/ioc/Container.test.ts` | Force GC before measuring retention |

An orchestrator's SIGTERM means "drain and go", and `forceExitAfter` already bounds the wait.
Explicit `server.stop()` calls keep their own `closeActiveConnections: true` default — programmatic
callers and test suites see no behavior change.

The `Container` retention test measured GC timing rather than retention: Bun 1.4 collects less
eagerly inside its 1s window, pushing a stable ~1046 KB past the 1 MB threshold. Forcing a
collection first makes it measure what it claims to.

## Test Plan

- [x] `bun test` — 1101/1101 on Bun 1.4.0
- [x] `bun test` — 1101/1101 on Bun 1.3.14 (`engines.bun >= 1.3.12`)
- [x] The new drain test fails with `ECONNRESET` when the fix is reverted
- [x] `bun run check` clean
- [x] `bun scripts/check-peer-ranges.ts` — 0.10.2 satisfies every dependent's range
- [x] E2E microservice R5 passes over both Redis and Kafka transports
