### PR TITLE
feat(adapter): context contract — getQuery undefined, appendResponseHeader, SSE comment

### DIFF
--- a/.changeset/context-contract-sse-comment.md
+++ b/.changeset/context-contract-sse-comment.md
@@ -1,0 +1,9 @@
+---
+"@asenajs/asena": minor
+---
+
+Three context-contract changes, each spelled out so adapter authors can implement against them:
+
+1. `AsenaContext.getQuery` now returns `Promise<string | undefined>`: `undefined` when the parameter is absent (never `''`); a parameter that is present but empty (`?name=`) is `''`. Adapters whose `getQuery` returned `''` for an absent key must return `undefined` instead.
+2. `setResponseHeader` is documented to *replace* any existing value for that header, and a new optional `appendResponseHeader(key, value)` member *appends*, keeping existing values - the semantics multi-valued headers such as `Vary` and `Link` need. Cookies still go through `setCookie`, not through either method. Both members are optional, so existing adapters keep compiling; adapters that want append semantics implement `appendResponseHeader`.
+3. `SSEMessage.data` is now optional and a new optional `comment` field emits `: <line>` lines (one per newline-separated line) that are invisible to `EventSource` clients - for keep-alive pings that must not look like an event. At least one of `data` / `comment` must be set; adapters throw when both are missing. Code that passed `data` as a required field keeps working unchanged.

--- a/lib/adapter/AsenaContext.ts
+++ b/lib/adapter/AsenaContext.ts
@@ -99,10 +99,13 @@ export interface AsenaContext<R, S extends Response> {
    * Retrieves a single query parameter value.
    * For URL "?name=john", getQuery("name") returns "john".
    *
+   * Returns `undefined` when the parameter is absent - never `''`. A parameter that is
+   * present but empty ("?name=") returns `''`.
+   *
    * @param {string} query - The query parameter name
-   * @returns {Promise<string>} The query parameter value
+   * @returns {Promise<string | undefined>} The query parameter value, or undefined when absent
    */
-  getQuery: (query: string) => Promise<string>;
+  getQuery: (query: string) => Promise<string | undefined>;
 
   /**
    * Retrieves all values for a query parameter that appears multiple times.
@@ -200,12 +203,23 @@ export interface AsenaContext<R, S extends Response> {
   getRequestIp?(): string | null;
 
   /**
-   * Set a response header.
+   * Set a response header, replacing any value already set for that header.
    *
    * @param {string} key - Header name
    * @param {string} value - Header value
    */
   setResponseHeader?(key: string, value: string): void;
+
+  /**
+   * Append a value to a response header, keeping any value(s) already set for it -
+   * the semantics multi-valued headers such as `Vary` and `Link` need. Use
+   * `setResponseHeader` to replace instead; cookies go through `setCookie`, not
+   * through this.
+   *
+   * @param {string} key - Header name
+   * @param {string} value - Header value to append
+   */
+  appendResponseHeader?(key: string, value: string): void;
 
   /**
    * Start a generic binary/text stream.

--- a/lib/adapter/types/Streaming.ts
+++ b/lib/adapter/types/Streaming.ts
@@ -1,10 +1,18 @@
 /**
  * SSE message format following the Server-Sent Events specification.
+ * At least one of `data` and `comment` must be set; adapters throw when both are
+ * missing, since such a frame would carry nothing at all.
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events
  */
 export interface SSEMessage {
   /** The data field. Multi-line strings are automatically split into separate data: lines. */
-  data: string;
+  data?: string;
+  /**
+   * Comment field, emitted as `: <line>` lines - one per newline-separated line -
+   * which are invisible to EventSource clients. Use it for keep-alive pings that
+   * must not look like an event.
+   */
+  comment?: string;
   /** Optional event type name */
   event?: string;
   /** Optional event ID for reconnection */

--- a/lib/ioc/component/decorators/OnStart.ts
+++ b/lib/ioc/component/decorators/OnStart.ts
@@ -4,10 +4,13 @@ import { defineTypedMetadata, getOwnTypedMetadata } from '../../../utils/typedMe
 /**
  * A decorator that marks a method to be called when the server starts.
  *
- * Runs during `server.start()`, after every component has been constructed and after the
- * application setup phase - configs are read, microservice transports are connected and
- * listening, routes are registered - but *before* the HTTP socket is bound. So a hook may
- * publish through `ulak`, and no request can arrive at a component that has not run yet.
+ * Runs during `server.start()`, after every component has been constructed and *before*
+ * the application setup phase - before `@Config` hooks are read, before microservice
+ * transports are connected, before routes are registered, before the HTTP socket is
+ * bound. So a hook cannot publish through `ulak`: the transports are not wired yet, and
+ * `ulak.send()` reports `NO_TRANSPORT`. In exchange, a `@Config` can use its injected
+ * components in `transport()` / `globalMiddlewares()` - their start hooks have already
+ * opened whatever those hooks open.
  *
  * Hooks run in registration order, which is the topological order the IoC engine computed:
  * a component's dependencies have already started when its own hook runs. A throwing hook

--- a/test/utils/TestContextWrapper.ts
+++ b/test/utils/TestContextWrapper.ts
@@ -65,7 +65,7 @@ export class TestContextWrapper implements AsenaContext<Request, Response> {
 
   public getBody = <U>() => Promise.resolve({} as U);
 
-  public getQuery = (_q: string) => Promise.resolve('');
+  public getQuery = (_q: string) => Promise.resolve<string | undefined>(undefined);
 
   public getQueryAll = (_q: string) => Promise.resolve([] as string[]);
 

--- a/test/utils/contextContract.types.ts
+++ b/test/utils/contextContract.types.ts
@@ -2,8 +2,13 @@
  * Compile-time contract test for the AsenaContext / SSEMessage surface.
  *
  * Not a *.test.ts file: it is never executed, only type-checked. `bun run typecheck`
- * includes test/**, so reverting any member this file relies on turns the gate red -
- * which is the only way to test a type-level contract.
+ * includes test/**, so removing `appendResponseHeader`, making `SSEMessage.data`
+ * required again or dropping `comment` turns the gate red.
+ *
+ * The `getQuery` line is documentary only: with `strictNullChecks` off (this repo's
+ * tsconfig) `string | undefined` collapses to `string`, and assignment is covariant
+ * anyway, so no type expression here can pin the `| undefined` half. The adapters' tests
+ * pin the runtime behaviour instead.
  */
 import type { AsenaContext } from '../../lib/adapter';
 import type { SSEMessage } from '../../lib/adapter/types';

--- a/test/utils/contextContract.types.ts
+++ b/test/utils/contextContract.types.ts
@@ -1,0 +1,17 @@
+/**
+ * Compile-time contract test for the AsenaContext / SSEMessage surface.
+ *
+ * Not a *.test.ts file: it is never executed, only type-checked. `bun run typecheck`
+ * includes test/**, so reverting any member this file relies on turns the gate red -
+ * which is the only way to test a type-level contract.
+ */
+import type { AsenaContext } from '../../lib/adapter';
+import type { SSEMessage } from '../../lib/adapter/types';
+
+declare const context: AsenaContext<Request, Response>;
+
+export const absent: Promise<string | undefined> = context.getQuery('name');
+
+context.appendResponseHeader?.('Vary', 'Origin');
+
+export const heartbeat: SSEMessage = { comment: 'ping' };

--- a/test/utils/createMockContext.ts
+++ b/test/utils/createMockContext.ts
@@ -23,7 +23,7 @@ export const createMockContext = () =>
     // @ts-ignore
     getBody: mock(<U>() => Promise.resolve({} satisfies U)),
 
-    getQuery: mock((_query: string) => Promise.resolve('')),
+    getQuery: mock((_query: string) => Promise.resolve<string | undefined>(undefined)),
     getQueryAll: mock((_query: string) => Promise.resolve([])),
 
     getCookie: mock((_name: string, _secret?: string | BufferSource) => Promise.resolve('')),


### PR DESCRIPTION
## Summary
- `AsenaContext.getQuery` now returns `Promise<string | undefined>`: `undefined` when the parameter is absent (never `''`); `?name=` (present but empty) is `''`.
- `setResponseHeader` JSDoc now states it REPLACES any existing value for that header; new optional `appendResponseHeader(key, value)` appends, keeping existing values (`Vary`, `Link`, ...); cookies stay on `setCookie`.
- `SSEMessage.data` is optional and a new `comment` field emits `: <line>` lines (one per newline-separated line), invisible to `EventSource` clients — for keep-alive pings; at least one of `data` / `comment` must be set, adapters throw when both are missing.
- `@OnStart` JSDoc rewritten to match `AsenaServer.start()`: hooks run after construction, BEFORE application setup — no `ulak` publishing (`NO_TRANSPORT`), in exchange a `@Config` can use its injected components in `transport()` / `globalMiddlewares()`.
- This repo owns the contract only; the hono and ergenecore adapters implement it in separate PRs.

## Changes
| file | change |
| --- | --- |
| `lib/adapter/AsenaContext.ts` | `getQuery` widened to `string \| undefined` + JSDoc; `setResponseHeader` replace-semantics JSDoc; new optional `appendResponseHeader` |
| `lib/adapter/types/Streaming.ts` | `SSEMessage.data` optional, new `comment` field, interface-level JSDoc on the data/comment requirement |
| `lib/ioc/component/decorators/OnStart.ts` | JSDoc only: ordering paragraphs corrected to pre-setup, no code change |
| `test/utils/contextContract.types.ts` | new compile-time contract test, enforced by `bun run typecheck` |
| `.changeset/context-contract-sse-comment.md` | minor bump for `@asenajs/asena` listing the three contract changes |

## Test plan
- [x] `bun test` — 1101 pass, 0 fail, 3182 expect() calls (run after `bun run build`; the 2 failures seen on an unbuilt tree are `@asenajs/asena/test` export resolution through missing `dist/`, unrelated to this diff)
- [x] `bun run check` — green (eslint 0 errors, warnings pre-existing; prettier clean)
- [x] `bun run build` — green
- [x] `bun run typecheck` — 3 errors, all pre-existing on master in `test/integration/fixtures/signal-drain-server.ts` (bun-types `Server<WebSocketData>` drift); proven by stashing this diff: identical 3 errors on a pristine tree. Zero new errors from this PR.
- [x] Red-green: with the lib change stashed, `bun run typecheck` additionally fails on `test/utils/contextContract.types.ts` with TS2339 for `appendResponseHeader` and `SSEMessage.comment`; restored, it passes.

## Untested
- No runtime test for `comment` formatting: `TestContextWrapper` does not implement `writeSSE`, and per the task the adapters own the behaviour tests.
- `README.md` unchanged: it documents none of `getQuery`, response headers, SSE or `@OnStart` ordering (verified by grep).
