### PR TITLE
fix(test): align the signal-drain fixture with bun-types 1.4

### DIFF
--- a/test/integration/fixtures/signal-drain-server.ts
+++ b/test/integration/fixtures/signal-drain-server.ts
@@ -21,7 +21,7 @@ class DrainFixtureAdapter extends AsenaAdapter<any, any> {
 
   private routes = new Map<string, RouteParams<any, any>>();
 
-  private server?: Bun.Server;
+  private server?: Bun.Server<any>;
 
   public constructor(logger: ServerLogger) {
     super(logger);
@@ -39,7 +39,7 @@ class DrainFixtureAdapter extends AsenaAdapter<any, any> {
     this.routes.set(key, params);
   }
 
-  public async start(): Promise<Bun.Server> {
+  public async start(): Promise<Bun.Server<any>> {
     this.server = Bun.serve({
       port: this.port,
       fetch: async (request) => {
@@ -49,7 +49,7 @@ class DrainFixtureAdapter extends AsenaAdapter<any, any> {
 
         if (!route) return new Response('not found', { status: 404 });
 
-        return new Response(String(await route.handler()));
+        return new Response(String(await (route.handler as () => unknown)()));
       },
     });
 


### PR DESCRIPTION
## Summary
- `bun run typecheck` fails on master with three errors in `test/integration/fixtures/signal-drain-server.ts`; `@types/bun` 1.4.0 (pinned in `bun.lock` since 0.10.2) made `Server` require its type argument and removed the zero-argument call the fixture used on the route handler.
- Fixture-only change; `lib/` already uses `Server<any>`.

## Changes
| file | change |
| --- | --- |
| `test/integration/fixtures/signal-drain-server.ts` | `Bun.Server` → `Bun.Server<any>` (field + `start()` return), handler call cast to a zero-arg function |

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun test test/integration/GracefulShutdown.test.ts` — 6 pass, 0 fail
- [x] `bun run check` — clean

## Untested
- nothing
