### PR TITLE
feat(ioc): add @Value configuration injection

### DIFF
--- a/.changeset/value-injection.md
+++ b/.changeset/value-injection.md
@@ -7,7 +7,8 @@ decorated with `@Value` are resolved from `process.env[key]` when the container 
 component: an optional `parse` function converts the raw string (e.g. `parse: Number`), and
 an optional `default` is used when the variable is not set — its presence is what counts, so
 `0`, `''` and `null` are honored. A variable that is not set on a field without a default
-fails the component's registration with an error naming the class, the field and the key.
+fails the component's construction (at registration for a singleton, at the first resolve for
+a transient) with an error naming the class, the field and the key.
 
 `mockComponent()` applies the same resolution, and a field present in its `overrides`
 option wins over the environment without reading it. Values land as plain writable

--- a/.changeset/value-injection.md
+++ b/.changeset/value-injection.md
@@ -1,0 +1,15 @@
+---
+"@asenajs/asena": minor
+---
+
+Adds a `@Value(key, options?)` property decorator for configuration injection. Fields
+decorated with `@Value` are resolved from `process.env[key]` when the container builds a
+component: an optional `parse` function converts the raw string (e.g. `parse: Number`), and
+an optional `default` is used when the variable is not set — its presence is what counts, so
+`0`, `''` and `null` are honored. A variable that is not set on a field without a default
+fails the component's registration with an error naming the class, the field and the key.
+
+`mockComponent()` applies the same resolution, and a field present in its `overrides`
+option wins over the environment without reading it. Values land as plain writable
+properties, and a field initializer keeps precedence over the environment. No breaking
+changes: existing decorators and container behaviour are untouched.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,26 @@ asena dev start
 
 Visit [asena.sh/docs/get-started](https://asena.sh/docs/get-started) for detailed setup instructions.
 
+## Dependency Injection
+
+Components wire their collaborators and configuration with field decorators. `@Inject`
+resolves another component by class, registered name or expression; `@Value` reads a
+configuration entry straight from the environment:
+
+```typescript
+@Service()
+class PoolService {
+  @Inject(DataSource)
+  private dataSource: DataSource;
+
+  @Value('DB_POOL_MAX', { parse: Number, default: 10 })
+  private poolMax: number;
+
+  @Value('JWT_SECRET') // required: no default, boot fails when unset
+  private jwtSecret: string;
+}
+```
+
 ## Performance
 
 Built on Bun runtime for exceptional performance:

--- a/README.md
+++ b/README.md
@@ -39,27 +39,6 @@ asena dev start
 ```
 
 Visit [asena.sh/docs/get-started](https://asena.sh/docs/get-started) for detailed setup instructions.
-
-## Dependency Injection
-
-Components wire their collaborators and configuration with field decorators. `@Inject`
-resolves another component by class, registered name or expression; `@Value` reads a
-configuration entry straight from the environment:
-
-```typescript
-@Service()
-class PoolService {
-  @Inject(DataSource)
-  private dataSource: DataSource;
-
-  @Value('DB_POOL_MAX', { parse: Number, default: 10 })
-  private poolMax: number;
-
-  @Value('JWT_SECRET') // required: no default, boot fails when unset
-  private jwtSecret: string;
-}
-```
-
 ## Performance
 
 Built on Bun runtime for exceptional performance:

--- a/lib/ioc/Container.ts
+++ b/lib/ioc/Container.ts
@@ -13,6 +13,7 @@ import { ComponentConstants } from './constants';
 import { getOwnTypedMetadata, getTypedMetadata } from '../utils';
 import { CircularDependencyDetector } from './CircularDependencyDetector';
 import { CORE_SERVICE } from './decorators';
+import { collectValueFields, readValue } from './helper/valueResolver';
 
 /**
  * The message behind an assignment to a wired field.
@@ -330,6 +331,8 @@ export class Container {
   private async prepareInstance<T>(Class: Class) {
     const newInstance = new Class();
 
+    this.injectValues(newInstance, Class); // configuration injection
+
     await this.injectDependencies(newInstance, Class); // dependency injection
 
     await this.injectStrategies(newInstance, Class); // strategy injection
@@ -474,6 +477,25 @@ export class Container {
           configurable: true,
         });
       }
+    }
+  }
+
+  /**
+   * @description Assigns every @Value field of the instance from process.env.
+   *
+   * Values land as plain writable properties - unlike @Inject fields they hold no
+   * resolved service to protect, and tests overwrite them freely. The own-property
+   * guard mirrors injectDependencies: a field initializer wins over the environment.
+   *
+   * @param {any} newInstance - The freshly constructed instance
+   * @param {Class} Class - The class of the instance
+   * @returns {void}
+   */
+  private injectValues(newInstance: any, Class: Class): void {
+    for (const [field, spec] of Object.entries(collectValueFields(Class))) {
+      if (Object.getOwnPropertyDescriptor(newInstance, field)?.value !== undefined) continue;
+
+      newInstance[field] = readValue(spec, Class, field);
     }
   }
 

--- a/lib/ioc/component/decorators/Value.ts
+++ b/lib/ioc/component/decorators/Value.ts
@@ -9,7 +9,8 @@ import { defineTypedMetadata, getOwnTypedMetadata } from '../../../utils/typedMe
  * A `parse` function converts the raw string (`parse: Number` for numbers); `default`
  * is used when the variable is not set, and its *presence* is what counts - `0`, `''`
  * and `null` are honored as defaults. A missing variable on a field without a default
- * fails the component's registration with an error naming the class and the field.
+ * fails the component's construction - at registration for a singleton, at the first
+ * resolve for a transient - with an error naming the class and the field.
  *
  * @param {string} key - Environment variable name
  * @param {ValueOptions} options - Optional `default` and `parse`

--- a/lib/ioc/component/decorators/Value.ts
+++ b/lib/ioc/component/decorators/Value.ts
@@ -1,0 +1,41 @@
+import type { ValueFields, ValueOptions } from '../../types';
+import { ComponentConstants } from '../../constants';
+import { defineTypedMetadata, getOwnTypedMetadata } from '../../../utils/typedMetadata';
+
+/**
+ * Property decorator to inject a configuration value from the environment.
+ *
+ * The value is read from `process.env[key]` when the container builds the component.
+ * A `parse` function converts the raw string (`parse: Number` for numbers); `default`
+ * is used when the variable is not set, and its *presence* is what counts - `0`, `''`
+ * and `null` are honored as defaults. A missing variable on a field without a default
+ * fails the component's registration with an error naming the class and the field.
+ *
+ * @param {string} key - Environment variable name
+ * @param {ValueOptions} options - Optional `default` and `parse`
+ * @returns {PropertyDecorator} - The property decorator function
+ *
+ * @example
+ * ```typescript
+ * @Value('DB_POOL_MAX', { parse: Number, default: 10 })
+ * private poolMax: number;
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Required: no default, boot fails when JWT_SECRET is not set
+ * @Value('JWT_SECRET')
+ * private jwtSecret: string;
+ * ```
+ */
+export const Value = (key: string, options: ValueOptions = {}): PropertyDecorator => {
+  return (target: object, propertyKey: string): void => {
+    const fields: ValueFields = getOwnTypedMetadata<ValueFields>(ComponentConstants.ValueKey, target.constructor) || {};
+
+    if (!fields[propertyKey]) {
+      fields[propertyKey] = { key, ...options };
+    }
+
+    defineTypedMetadata<ValueFields>(ComponentConstants.ValueKey, fields, target.constructor);
+  };
+};

--- a/lib/ioc/component/decorators/index.ts
+++ b/lib/ioc/component/decorators/index.ts
@@ -1,4 +1,5 @@
 export * from './Inject';
+export * from './Value';
 export * from './Implements';
 export * from '../componentUtils';
 export * from './Strategy';

--- a/lib/ioc/constants/ComponentConstants.ts
+++ b/lib/ioc/constants/ComponentConstants.ts
@@ -22,6 +22,8 @@ export class ComponentConstants {
 
   public static readonly ExpressionKey = Symbol('component:expression');
 
+  public static readonly ValueKey = Symbol('component:value');
+
   // Start hooks. The key keeps the old name because @PostConstruct is still a supported alias
   // for @OnStart and both must land in the same list.
   public static readonly PostConstructKey = Symbol('component:postConstruct');

--- a/lib/ioc/helper/valueResolver.ts
+++ b/lib/ioc/helper/valueResolver.ts
@@ -1,40 +1,18 @@
 import type { Class } from '../../server/types';
 import type { ValueFields, ValueSpec } from '../types';
 import { ComponentConstants } from '../constants';
-import { getOwnTypedMetadata } from '../../utils/typedMetadata';
+import { getChainedTypedMetadata } from '../../utils/typedMetadata';
 
 /**
- * Collects the @Value fields of a class as a single record.
- *
- * Same walk and stop rules as the test utilities' discovery: up the constructor chain,
- * halting at `Function.prototype` or a class whose source reads `[native code]`. The
- * chain is merged ancestors-first, so a field redeclared in a subclass overwrites the
- * base class entry - the same subclass-wins rule @Inject fields follow.
+ * Collects the @Value fields of a class as a single record: the whole prototype chain,
+ * ancestors first, so a field redeclared in a subclass overwrites the base class entry -
+ * the same subclass-wins rule @Inject fields follow.
  *
  * @param ComponentClass - Component class to inspect
  * @returns The merged `{ [field]: { key, default?, parse? } }` record
  */
 export function collectValueFields(ComponentClass: any): ValueFields {
-  const chain: any[] = [];
-
-  let currentClass = ComponentClass;
-
-  while (currentClass && currentClass !== Function.prototype) {
-    if (typeof currentClass !== 'function' || currentClass.toString().includes('[native code]')) {
-      break;
-    }
-
-    chain.unshift(currentClass);
-    currentClass = Object.getPrototypeOf(currentClass);
-  }
-
-  const fields: ValueFields = {};
-
-  for (const classInChain of chain) {
-    Object.assign(fields, getOwnTypedMetadata<ValueFields>(ComponentConstants.ValueKey, classInChain) || {});
-  }
-
-  return fields;
+  return getChainedTypedMetadata<ValueFields>(ComponentConstants.ValueKey, ComponentClass);
 }
 
 /**

--- a/lib/ioc/helper/valueResolver.ts
+++ b/lib/ioc/helper/valueResolver.ts
@@ -1,0 +1,67 @@
+import type { Class } from '../../server/types';
+import type { ValueFields, ValueSpec } from '../types';
+import { ComponentConstants } from '../constants';
+import { getOwnTypedMetadata } from '../../utils/typedMetadata';
+
+/**
+ * Collects the @Value fields of a class as a single record.
+ *
+ * Same walk and stop rules as the test utilities' discovery: up the constructor chain,
+ * halting at `Function.prototype` or a class whose source reads `[native code]`. The
+ * chain is merged ancestors-first, so a field redeclared in a subclass overwrites the
+ * base class entry - the same subclass-wins rule @Inject fields follow.
+ *
+ * @param ComponentClass - Component class to inspect
+ * @returns The merged `{ [field]: { key, default?, parse? } }` record
+ */
+export function collectValueFields(ComponentClass: any): ValueFields {
+  const chain: any[] = [];
+
+  let currentClass = ComponentClass;
+
+  while (currentClass && currentClass !== Function.prototype) {
+    if (typeof currentClass !== 'function' || currentClass.toString().includes('[native code]')) {
+      break;
+    }
+
+    chain.unshift(currentClass);
+    currentClass = Object.getPrototypeOf(currentClass);
+  }
+
+  const fields: ValueFields = {};
+
+  for (const classInChain of chain) {
+    Object.assign(fields, getOwnTypedMetadata<ValueFields>(ComponentConstants.ValueKey, classInChain) || {});
+  }
+
+  return fields;
+}
+
+/**
+ * Resolves one @Value field against `process.env`.
+ *
+ * A set variable wins and goes through `parse` when one was given. An unset variable
+ * falls back to `default` - presence of the option, not its truthiness, so `0`, `''`
+ * and `null` are respected - and only a field with neither throws.
+ *
+ * @param spec - The stored field metadata: env key plus options
+ * @param Class - The class owning the field, for the error message
+ * @param field - The field name, for the error message
+ * @returns The resolved value: parsed env string, or the default
+ * @throws When the variable is not set and no default was given
+ */
+export function readValue(spec: ValueSpec, Class: Class, field: string): unknown {
+  const raw = process.env[spec.key];
+
+  if (raw !== undefined) {
+    return spec.parse ? spec.parse(raw) : raw;
+  }
+
+  if ('default' in spec) {
+    return spec.default;
+  }
+
+  throw new Error(
+    `@Value('${spec.key}') on ${Class.name}.${field}: environment variable is not set and no default was given`,
+  );
+}

--- a/lib/ioc/types/InjectableComponent.ts
+++ b/lib/ioc/types/InjectableComponent.ts
@@ -27,3 +27,24 @@ export interface Expressions {
 export interface Strategies {
   [key: string]: string;
 }
+
+/**
+ * Options accepted by the @Value decorator. `default` is applied when the environment
+ * variable is not set; `parse` converts the raw string before it lands on the field.
+ */
+export interface ValueOptions {
+  default?: unknown;
+  parse?: (raw: string) => unknown;
+}
+
+/**
+ * The stored @Value metadata for one field. `default` is only present when the option
+ * was given, so "was a default provided?" stays distinguishable from its value.
+ */
+export interface ValueSpec extends ValueOptions {
+  key: string;
+}
+
+export interface ValueFields {
+  [field: string]: ValueSpec;
+}

--- a/lib/test/metadata/discovery.ts
+++ b/lib/test/metadata/discovery.ts
@@ -1,7 +1,8 @@
-import type { DependencyClasses, Dependencies, Expressions } from '../../ioc';
+import type { DependencyClasses, Dependencies, Expressions, ValueFields } from '../../ioc';
 import type { FieldMetadata } from '../types';
 import { ComponentConstants } from '../../ioc';
 import { getOwnTypedMetadata } from '../../utils';
+import { collectValueFields } from '../../ioc/helper/valueResolver';
 
 /**
  * Discovers all fields with @Inject decorator in a component
@@ -109,6 +110,20 @@ export function discoverInjectedFieldsFromClass(ComponentClass: any): FieldMetad
  */
 export function hasInjectedFields(ComponentClass: new (...args: any[]) => any): boolean {
   return discoverInjectedFieldsFromClass(ComponentClass).length > 0;
+}
+
+/**
+ * Discovers all fields with the @Value decorator in a component class
+ *
+ * Thin re-export of the container's shared walk, so mockComponent and the container
+ * always agree on which value fields a class carries - including inherited ones,
+ * with subclass redeclarations winning.
+ *
+ * @param ComponentClass - Component class to inspect
+ * @returns The merged `{ [field]: { key, default?, parse? } }` record
+ */
+export function discoverValueFieldsFromClass(ComponentClass: any): ValueFields {
+  return collectValueFields(ComponentClass);
 }
 
 /**

--- a/lib/test/mockComponent.ts
+++ b/lib/test/mockComponent.ts
@@ -94,14 +94,15 @@ export function mockComponent<T extends object>(
   const instance = new ComponentClass();
   const allInjectedFields = discoverInjectedFields(instance);
 
-  // @Value fields resolve before @Inject mocking, mirroring the container's
-  // prepareInstance order. An override is the FINAL value and skips the env read
-  // entirely; resolved values are not mocks and stay out of `mocks`.
+  // Same precedence as the container: override > field initializer > environment.
+  // Resolved values are not mocks and stay out of `mocks`.
   for (const [field, spec] of Object.entries(discoverValueFieldsFromClass(ComponentClass))) {
     if (options.overrides && Object.hasOwn(options.overrides, field)) {
       (instance as any)[field] = options.overrides[field];
       continue;
     }
+
+    if (Object.getOwnPropertyDescriptor(instance, field)?.value !== undefined) continue;
 
     (instance as any)[field] = readValue(spec, ComponentClass, field);
   }

--- a/lib/test/mockComponent.ts
+++ b/lib/test/mockComponent.ts
@@ -1,5 +1,6 @@
 import type { MockComponentOptions, MockedComponent } from './types';
-import { discoverInjectedFields } from './metadata/discovery';
+import { discoverInjectedFields, discoverValueFieldsFromClass } from './metadata/discovery';
+import { readValue } from '../ioc/helper/valueResolver';
 import { createMockFromClass } from './factory/mockFactory';
 import { createDeepMock } from './factory/deepMock';
 
@@ -92,6 +93,18 @@ export function mockComponent<T extends object>(
 
   const instance = new ComponentClass();
   const allInjectedFields = discoverInjectedFields(instance);
+
+  // @Value fields resolve before @Inject mocking, mirroring the container's
+  // prepareInstance order. An override is the FINAL value and skips the env read
+  // entirely; resolved values are not mocks and stay out of `mocks`.
+  for (const [field, spec] of Object.entries(discoverValueFieldsFromClass(ComponentClass))) {
+    if (options.overrides && Object.hasOwn(options.overrides, field)) {
+      (instance as any)[field] = options.overrides[field];
+      continue;
+    }
+
+    (instance as any)[field] = readValue(spec, ComponentClass, field);
+  }
 
   const fieldsToMock = options.injections
     ? allInjectedFields.filter((field) => options.injections.includes(field.fieldName))

--- a/test/ioc/Value.test.ts
+++ b/test/ioc/Value.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Container } from '../../lib/ioc';
+import { Component } from '../../lib/server/decorators';
+import { Value } from '../../lib/ioc/component';
+
+const touchedKeys: string[] = [];
+
+const setEnv = (key: string, value: string | undefined): void => {
+  touchedKeys.push(key);
+
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+};
+
+@Component()
+class UrlService {
+  @Value('ASENA_TEST_VALUE_URL')
+  private url: string;
+
+  public getUrl(): string {
+    return this.url;
+  }
+}
+
+@Component()
+class PoolService {
+  @Value('ASENA_TEST_VALUE_POOL_MAX', { parse: Number, default: 10 })
+  private poolMax: number;
+
+  public getPoolMax(): number {
+    return this.poolMax;
+  }
+}
+
+@Component()
+class DefaultingService {
+  @Value('ASENA_TEST_VALUE_ZERO', { default: 0 })
+  private zero: number;
+
+  @Value('ASENA_TEST_VALUE_EMPTY', { default: '' })
+  private empty: string;
+
+  @Value('ASENA_TEST_VALUE_NULL', { default: null })
+  private nullable: unknown;
+
+  public getZero(): number {
+    return this.zero;
+  }
+
+  public getEmpty(): string {
+    return this.empty;
+  }
+
+  public getNullable(): unknown {
+    return this.nullable;
+  }
+}
+
+@Component()
+class RequiredService {
+  @Value('ASENA_TEST_VALUE_REQUIRED')
+  private requiredField: string;
+
+  public getRequired(): string {
+    return this.requiredField;
+  }
+}
+
+@Component()
+class BaseValueService {
+  @Value('ASENA_TEST_VALUE_BASE')
+  public baseField: string;
+}
+
+@Component()
+class SubValueService extends BaseValueService {
+  @Value('ASENA_TEST_VALUE_SUB')
+  public override baseField: string;
+}
+
+@Component()
+class InheritingService extends BaseValueService {
+  public readBaseField(): string {
+    return this.baseField;
+  }
+}
+
+@Component()
+class InitializedService {
+  @Value('ASENA_TEST_VALUE_INITIALIZER')
+  private field = 'initializer-value';
+
+  public getField(): string {
+    return this.field;
+  }
+}
+
+describe('@Value configuration injection', () => {
+  afterEach(() => {
+    for (const key of touchedKeys.splice(0)) {
+      delete process.env[key];
+    }
+  });
+
+  test('reads a set variable from the environment', async () => {
+    setEnv('ASENA_TEST_VALUE_URL', 'postgres://localhost/app');
+
+    const container = new Container();
+    await container.register('UrlService', UrlService, true);
+
+    const instance = (await container.resolve<UrlService>('UrlService')) as UrlService;
+
+    expect(instance.getUrl()).toBe('postgres://localhost/app');
+  });
+
+  test('parse: Number converts the raw string', async () => {
+    setEnv('ASENA_TEST_VALUE_POOL_MAX', '30');
+
+    const container = new Container();
+    await container.register('PoolService', PoolService, true);
+
+    const instance = (await container.resolve<PoolService>('PoolService')) as PoolService;
+
+    expect(instance.getPoolMax()).toBe(30);
+  });
+
+  test('default is used when the variable is unset, including 0 and empty string', async () => {
+    const container = new Container();
+    await container.register('DefaultingService', DefaultingService, true);
+
+    const instance = (await container.resolve<DefaultingService>('DefaultingService')) as DefaultingService;
+
+    expect(instance.getZero()).toBe(0);
+    expect(instance.getEmpty()).toBe('');
+    expect(instance.getNullable()).toBe(null);
+  });
+
+  test('default is used when the variable is unset even for a parsed field', async () => {
+    const container = new Container();
+    await container.register('PoolService', PoolService, true);
+
+    const instance = (await container.resolve<PoolService>('PoolService')) as PoolService;
+
+    expect(instance.getPoolMax()).toBe(10);
+  });
+
+  test('unset variable with no default fails registration naming class, field and key', async () => {
+    const container = new Container();
+
+    await expect(container.register('RequiredService', RequiredService, true)).rejects.toThrow(
+      "@Value('ASENA_TEST_VALUE_REQUIRED') on RequiredService.requiredField: environment variable is not set and no default was given",
+    );
+  });
+
+  test('a @Value on a base class is applied to the subclass instance', async () => {
+    setEnv('ASENA_TEST_VALUE_BASE', 'from-base');
+
+    const container = new Container();
+    await container.register('InheritingService', InheritingService, true);
+
+    const instance = (await container.resolve<InheritingService>('InheritingService')) as InheritingService;
+
+    expect(instance.readBaseField()).toBe('from-base');
+  });
+
+  test('a subclass redeclaring the field with another key wins', async () => {
+    setEnv('ASENA_TEST_VALUE_BASE', 'from-base');
+    setEnv('ASENA_TEST_VALUE_SUB', 'from-sub');
+
+    const container = new Container();
+    await container.register('SubValueService', SubValueService, true);
+
+    const instance = (await container.resolve<SubValueService>('SubValueService')) as SubValueService;
+
+    expect(instance.baseField).toBe('from-sub');
+    expect(instance.baseField).not.toBe('from-base');
+  });
+
+  test('a field with an initializer is not overwritten', async () => {
+    setEnv('ASENA_TEST_VALUE_INITIALIZER', 'from-env');
+
+    const container = new Container();
+    await container.register('InitializedService', InitializedService, true);
+
+    const instance = (await container.resolve<InitializedService>('InitializedService')) as InitializedService;
+
+    expect(instance.getField()).toBe('initializer-value');
+  });
+
+  test('the resolved value is a plain writable property, not an accessor', async () => {
+    setEnv('ASENA_TEST_VALUE_URL', 'postgres://localhost/app');
+
+    const container = new Container();
+    await container.register('UrlService', UrlService, true);
+
+    const instance = (await container.resolve<UrlService>('UrlService')) as UrlService;
+    const descriptor = Object.getOwnPropertyDescriptor(instance, 'url');
+
+    expect(descriptor?.get).toBeUndefined();
+    expect(descriptor?.set).toBeUndefined();
+    expect(descriptor?.writable).toBe(true);
+
+    (instance as any)['url'] = 'overwritten';
+    expect(instance.getUrl()).toBe('overwritten');
+  });
+});

--- a/test/ioc/Value.test.ts
+++ b/test/ioc/Value.test.ts
@@ -155,6 +155,18 @@ describe('@Value configuration injection', () => {
     );
   });
 
+  test('a transient defers the missing-variable error to its first resolve', async () => {
+    setEnv('ASENA_TEST_VALUE_URL', undefined);
+
+    const container = new Container();
+
+    await container.register('UrlService', UrlService, false);
+
+    await expect(container.resolve('UrlService')).rejects.toThrow(
+      "@Value('ASENA_TEST_VALUE_URL') on UrlService.url: environment variable is not set and no default was given",
+    );
+  });
+
   test('a @Value on a base class is applied to the subclass instance', async () => {
     setEnv('ASENA_TEST_VALUE_BASE', 'from-base');
 

--- a/test/test/mockComponent.test.ts
+++ b/test/test/mockComponent.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 // Imported from lib/ (not the @asenajs/asena/test specifier, which resolves to dist/) so a
 // stale build cannot mask a regression. All four must come from the same tree: metadata keys
 // are Symbols created per module instance, so mixing lib/ and dist/ makes them invisible.
 import { createTestUlakStub, mockComponent, mockComponentAsync } from '../../lib/test';
 import { Component } from '../../lib/server/decorators';
-import { Inject } from '../../lib/ioc/component';
+import { Inject, Value } from '../../lib/ioc/component';
 import { ulak, type Ulak } from '../../lib/server/messaging';
 
 @Component()
@@ -513,6 +513,48 @@ describe('mockComponent', () => {
       expect(mocks['database']).toBeDefined();
       expect((instance as any).logger).toBe(mocks['logger']);
       expect((instance as any).database).toBe(mocks['database']);
+    });
+  });
+
+  describe('@Value fields', () => {
+    const ENV_KEY = 'ASENA_TEST_MOCK_VALUE';
+
+    afterEach(() => {
+      delete process.env[ENV_KEY];
+    });
+
+    @Component()
+    class ServiceWithValue {
+      @Inject(UserService)
+      private userService: UserService;
+
+      @Value(ENV_KEY)
+      private configValue: string;
+
+      public async createUser(name: string, email: string) {
+        await this.userService.createUser(name, email);
+        return this.configValue;
+      }
+    }
+
+    test('applies the env value and keeps it out of mocks', () => {
+      process.env[ENV_KEY] = 'from-env';
+
+      const { instance, mocks } = mockComponent(ServiceWithValue);
+
+      expect((instance as any).configValue).toBe('from-env');
+      expect(mocks['configValue']).toBeUndefined();
+      expect(mocks['userService']).toBeDefined();
+    });
+
+    test('an override wins and the env is not read at all', () => {
+      // ENV_KEY is unset: without the override short-circuiting the env read,
+      // readValue would throw for the missing required value
+      const { instance } = mockComponent(ServiceWithValue, {
+        overrides: { configValue: 'from-override' },
+      });
+
+      expect((instance as any).configValue).toBe('from-override');
     });
   });
 });

--- a/test/test/mockComponent.test.ts
+++ b/test/test/mockComponent.test.ts
@@ -537,6 +537,24 @@ describe('mockComponent', () => {
       }
     }
 
+    test('a field initializer wins over the environment, as in the container', () => {
+      // ENV_KEY is unset and the field has no default: without the initializer guard
+      // mockComponent would throw where the container builds the class fine
+      @Component()
+      class InitializedService {
+        @Value(ENV_KEY)
+        private configValue = 'from-initializer';
+
+        public get(): string {
+          return this.configValue;
+        }
+      }
+
+      const { instance } = mockComponent(InitializedService);
+
+      expect(instance.get()).toBe('from-initializer');
+    });
+
     test('applies the env value and keeps it out of mocks', () => {
       process.env[ENV_KEY] = 'from-env';
 


### PR DESCRIPTION
## Summary

- Adds a `@Value(key, options?)` property decorator that injects configuration from `process.env`, so services no longer need an `env.ts` plus a context component ferrying strings into classes.
- Optional `parse` converts the raw string (`parse: Number`); optional `default` is used when the variable is unset, with option *presence* deciding — `0`, `''` and `null` are honored.
- A required value (no default) that is unset fails `container.register` with an error naming the class, the field and the key.
- Resolution is shared by the container and the test utilities: `mockComponent()` applies env values before mocking `@Inject` fields, and a field in `options.overrides` wins without reading the environment; value fields stay out of `mocks`.
- Values land as plain writable properties (not read-only accessors like `@Inject`), and a field initializer keeps precedence over the environment, mirroring the existing injection guard.

## Changes

| File | Change |
|---|---|
| `lib/ioc/component/decorators/Value.ts` | New `@Value` decorator storing own metadata under `ComponentConstants.ValueKey` |
| `lib/ioc/constants/ComponentConstants.ts` | New `ValueKey` symbol |
| `lib/ioc/types/InjectableComponent.ts` | New `ValueOptions`, `ValueSpec`, `ValueFields` types |
| `lib/ioc/helper/valueResolver.ts` | New shared resolver: `collectValueFields` (chain walk, subclass wins) and `readValue` (env → parse → default → throw) |
| `lib/ioc/Container.ts` | `prepareInstance` applies `injectValues` before `injectDependencies`, with the same own-property guard |
| `lib/test/metadata/discovery.ts` | `discoverValueFieldsFromClass` as a thin re-export of the shared walk |
| `lib/test/mockComponent.ts` | Resolves `@Value` fields before the mock loop; overrides skip the env read; values not added to `mocks` |
| `test/ioc/Value.test.ts` | New: env read, `parse: Number`, defaults (incl. `0`, `''`, `null`), exact error from `register`, base-class inheritance, subclass redeclaration, initializer precedence, writable property |
| `test/test/mockComponent.test.ts` | New cases: env value applied (not in `mocks`); override wins with unset env |
| `README.md` | Short Dependency Injection section with `@Inject` and `@Value` |

## Test plan

- [x] `bun test` — 1112 pass, 0 fail (master baseline: 1101 pass, 0 fail after build)
- [x] `bun run check` (eslint + prettier) — green
- [x] `bun run build` — green
- [x] Red-green: with the lib changes stashed, `bun test test/ioc/Value.test.ts test/test/mockComponent.test.ts` fails (0 pass, 2 fail — `Value` export missing); with the changes, all pass
- [x] `test/ioc/SymbolKeys.test.ts` needs no change — it enumerates `ComponentConstants` reflectively

## Untested

- `bun run typecheck` reports 3 pre-existing errors in `test/integration/fixtures/signal-drain-server.ts` (`Server<WebSocketData>` generic, bun-types drift). Verified they occur identically with this branch's changes stashed; no errors originate from the files touched here.
